### PR TITLE
Fix number of arguments mismatch (nosetests)

### DIFF
--- a/pyvips/tests/test_arithmetic.py
+++ b/pyvips/tests/test_arithmetic.py
@@ -29,17 +29,17 @@ class TestArithmetic(unittest.TestCase):
 
     # run a function on (image, constant), and on (constant, image).
     # 50,50 and 10,10 should have different values on the test image
-    def run_testconst(self, message, fn, im, c):
+    def _run_testconst(self, message, fn, im, c):
         self.run_cmp(message, im, 50, 50, lambda x: run_fn2(fn, x, c))
         self.run_cmp(message, im, 50, 50, lambda x: run_fn2(fn, c, x))
         self.run_cmp(message, im, 10, 10, lambda x: run_fn2(fn, x, c))
         self.run_cmp(message, im, 10, 10, lambda x: run_fn2(fn, c, x))
 
     def run_arith_const(self, fn, fmt = all_formats):
-        [self.run_testconst(fn.__name__ + ' scalar', fn, x.cast(y), 2)
+        [self._run_testconst(fn.__name__ + ' scalar', fn, x.cast(y), 2)
          for x in self.all_images for y in fmt]
-        [self.run_testconst(fn.__name__ + ' vector', fn, self.colour.cast(y), 
-                            [1, 2, 3])
+        [self._run_testconst(fn.__name__ + ' vector', fn, self.colour.cast(y),
+                             [1, 2, 3])
          for y in fmt]
 
     # run a function on a pair of images and on a pair of pixels, the results 
@@ -54,14 +54,14 @@ class TestArithmetic(unittest.TestCase):
 
     # run a function on a pair of images
     # 50,50 and 10,10 should have different values on the test image
-    def run_test2(self, message, left, right, fn):
+    def _run_test2(self, message, left, right, fn):
         self.run_cmp2(message, left, right, 50, 50, 
                       lambda x, y: run_fn2(fn, x, y))
         self.run_cmp2(message, left, right, 10, 10, 
                       lambda x, y: run_fn2(fn, x, y))
 
     def run_arith(self, fn, fmt = all_formats):
-        [self.run_test2(fn.__name__ + ' image', x.cast(y), x.cast(z), fn)
+        [self._run_test2(fn.__name__ + ' image', x.cast(y), x.cast(z), fn)
          for x in self.all_images for y in fmt for z in fmt]
 
     def setUp(self):
@@ -233,12 +233,12 @@ class TestArithmetic(unittest.TestCase):
 
     # run a function on an image, 
     # 50,50 and 10,10 should have different values on the test image
-    def run_testunary(self, message, im, fn):
+    def _run_testunary(self, message, im, fn):
         self.run_cmp(message, im, 50, 50, lambda x: run_fn(fn, x))
         self.run_cmp(message, im, 10, 10, lambda x: run_fn(fn, x))
 
     def run_unary(self, images, fn, fmt = all_formats):
-        [self.run_testunary(fn.__name__ + ' image', x.cast(y), fn)
+        [self._run_testunary(fn.__name__ + ' image', x.cast(y), fn)
          for x in images for y in fmt]
 
     def test_abs(self):

--- a/pyvips/tests/test_colour.py
+++ b/pyvips/tests/test_colour.py
@@ -39,14 +39,6 @@ class TestColour(unittest.TestCase):
         v2 = after(x, y)
         self.assertAlmostEqualObjects(v1, v2, msg = message)
 
-    # run a function on a pair of images
-    # 50,50 and 10,10 should have different values on the test image
-    def run_test2(self, message, left, right, fn):
-        self.run_cmp2(message, left, right, 50, 50, 
-                      lambda x, y: run_fn2(fn, x, y))
-        self.run_cmp2(message, left, right, 10, 10, 
-                      lambda x, y: run_fn2(fn, x, y))
-
     def setUp(self):
         im = pyvips.Image.mask_ideal(100, 100, 0.5, reject = True, optical = True)
         self.colour = im * [1, 2, 3] + [2, 3, 4]

--- a/pyvips/tests/test_conversion.py
+++ b/pyvips/tests/test_conversion.py
@@ -42,23 +42,23 @@ class TestConversion(unittest.TestCase):
 
     # run a function on a pair of images
     # 50,50 and 10,10 should have different values on the test image
-    def run_testbinary(self, message, left, right, fn):
+    def _run_testbinary(self, message, left, right, fn):
         self.run_cmp_binary(message, left, right, 50, 50, fn)
         self.run_cmp_binary(message, left, right, 10, 10, fn)
 
     # run a function on an image, 
     # 50,50 and 10,10 should have different values on the test image
-    def run_testunary(self, message, im, fn):
+    def _run_testunary(self, message, im, fn):
         self.run_cmp_unary(message, im, 50, 50, fn)
         self.run_cmp_unary(message, im, 10, 10, fn)
 
     def run_unary(self, images, fn, fmt = all_formats):
-        [self.run_testunary(fn.__name__ + (' %s' % y), x.cast(y), fn)
+        [self._run_testunary(fn.__name__ + (' %s' % y), x.cast(y), fn)
          for x in images for y in fmt]
 
     def run_binary(self, images, fn, fmt = all_formats):
-        [self.run_testbinary(fn.__name__ + (' %s %s' % (y, z)), 
-                             x.cast(y), x.cast(z), fn)
+        [self._run_testbinary(fn.__name__ + (' %s %s' % (y, z)),
+                              x.cast(y), x.cast(z), fn)
          for x in images for y in fmt for z in fmt]
 
     def setUp(self):


### PR DESCRIPTION
Start some function names with an underscore, so nose will ignore it. This will fix the `takes exactly * arguments (* given)` errors.

Nose can be a little too zealous about finding and running anything that looks like a test. (It tries to run tests with the word _test_ in it).

If I run
```
nosetests --logging-level=WARNING &> vips_output.log
```

I see this:
[vips_output.zip](https://github.com/jcupitt/pyvips/files/1199975/vips_output.zip)

- Missing `images/sRGB.icm`
- Error in `dont_test_conva` (should we disable that test?)
- Error in `test_magickload` (bands == 3 instead of 4)
- Segmentation fault in *magick.