### PR TITLE
Python 3 support

### DIFF
--- a/pyvips/base.py
+++ b/pyvips/base.py
@@ -65,7 +65,7 @@ class Error(Exception):
     def __init__(self, message, detail = None):
         self.message = message
         if detail == None or detail == "":
-            detail = ffi.string(vips_lib.vips_error_buffer())
+            detail = ffi.string(vips_lib.vips_error_buffer()).decode('utf-8')
             vips_lib.vips_error_clear()
         self.detail = detail
 
@@ -88,17 +88,16 @@ def leak_set(leak):
     return vips_lib.vips_leak_set(leak)
 
 def path_filename7(filename):
-    return ffi.string(vips_lib.vips_path_filename7(bytes(filename, 'utf-8')))
+    return ffi.string(vips_lib.vips_path_filename7(filename.encode())).decode('utf-8')
 
 def path_mode7(filename):
-    return ffi.string(vips_lib.vips_path_mode7(bytes(filename, 'utf-8')))
+    return ffi.string(vips_lib.vips_path_mode7(filename.encode())).decode('utf-8')
 
 def type_find(basename, nickname):
-    return vips_lib.vips_type_find(bytes(basename, 'utf-8'), 
-                                   bytes(nickname, 'utf-8'))
+    return vips_lib.vips_type_find(basename.encode(), nickname.encode())
 
 def type_name(gtype):
-    return(ffi.string(gobject_lib.g_type_name(gtype)))
+    return ffi.string(gobject_lib.g_type_name(gtype)).decode('utf-8')
 
 __all__ = ['ffi', 'vips_lib', 'gobject_lib', 'Error', 'leak_set', 
            'type_find', 'type_name',

--- a/pyvips/tests/helpers.py
+++ b/pyvips/tests/helpers.py
@@ -4,12 +4,7 @@
 from __future__ import division
 import os
 import unittest
-import operator
-import math
-from functools import reduce
-import shutil
 import tempfile
-from tempfile import NamedTemporaryFile
 
 import pyvips
 

--- a/pyvips/tests/test_arithmetic.py
+++ b/pyvips/tests/test_arithmetic.py
@@ -1,6 +1,7 @@
 # vim: set fileencoding=utf-8 :
 
-from helpers import *
+import math
+from .helpers import *
 
 class TestArithmetic(PyvipsTester):
     def run_arith(self, fn, fmt = all_formats):

--- a/pyvips/tests/test_colour.py
+++ b/pyvips/tests/test_colour.py
@@ -1,6 +1,6 @@
 # vim: set fileencoding=utf-8 :
 
-from helpers import * 
+from .helpers import *
 
 class TestColour(PyvipsTester):
     def setUp(self):

--- a/pyvips/tests/test_conversion.py
+++ b/pyvips/tests/test_conversion.py
@@ -1,10 +1,11 @@
 # vim: set fileencoding=utf-8 :
 
-from helpers import * 
+from functools import reduce
+from .helpers import *
 
 class TestConversion(PyvipsTester):
 
-    # run a function on an image, 
+    # run a function on an image,
     # 50,50 and 10,10 should have different values on the test image
     # don't loop over band elements
     def run_image_pixels(self, message, im, fn):
@@ -23,12 +24,12 @@ class TestConversion(PyvipsTester):
          for x in images for y in fmt]
 
     def run_binary(self, images, fn, fmt = all_formats):
-        [self.run_image_pixels2(fn.__name__ + (' %s %s' % (y, z)), 
+        [self.run_image_pixels2(fn.__name__ + (' %s %s' % (y, z)),
                          x.cast(y), x.cast(z), fn)
          for x in images for y in fmt for z in fmt]
 
     def setUp(self):
-        im = pyvips.Image.mask_ideal(100, 100, 0.5, 
+        im = pyvips.Image.mask_ideal(100, 100, 0.5,
                                      reject = True, optical = True)
         self.colour = im * [1, 2, 3] + [2, 3, 4]
         self.mono = self.colour[1]
@@ -165,7 +166,7 @@ class TestConversion(PyvipsTester):
         for fmt in all_formats:
             test = self.colour.cast(fmt)
 
-            im = test.embed(20, 20, 
+            im = test.embed(20, 20,
                             self.colour.width + 40,
                             self.colour.height + 40)
             pixel = im(10, 10)
@@ -175,7 +176,7 @@ class TestConversion(PyvipsTester):
             pixel = im(im.width - 10, im.height - 10)
             self.assertAlmostEqualObjects(pixel, [0, 0, 0])
 
-            im = test.embed(20, 20, 
+            im = test.embed(20, 20,
                             self.colour.width + 40,
                             self.colour.height + 40,
                             extend = pyvips.Extend.COPY)
@@ -184,7 +185,7 @@ class TestConversion(PyvipsTester):
             pixel = im(im.width - 10, im.height - 10)
             self.assertAlmostEqualObjects(pixel, [2, 3, 4])
 
-            im = test.embed(20, 20, 
+            im = test.embed(20, 20,
                             self.colour.width + 40,
                             self.colour.height + 40,
                             extend = pyvips.Extend.BACKGROUND,
@@ -194,7 +195,7 @@ class TestConversion(PyvipsTester):
             pixel = im(im.width - 10, im.height - 10)
             self.assertAlmostEqualObjects(pixel, [7, 8, 9])
 
-            im = test.embed(20, 20, 
+            im = test.embed(20, 20,
                             self.colour.width + 40,
                             self.colour.height + 40,
                             extend = pyvips.Extend.WHITE)
@@ -279,7 +280,7 @@ class TestConversion(PyvipsTester):
             self.assertAlmostEqualObjects(pixel, [20, 0, 41])
 
     def test_flatten(self):
-        for fmt in unsigned_formats + [pyvips.BandFormat.SHORT, 
+        for fmt in unsigned_formats + [pyvips.BandFormat.SHORT,
                 pyvips.BandFormat.INT] + float_formats:
             mx = 255
             alpha = mx / 2.0
@@ -310,7 +311,7 @@ class TestConversion(PyvipsTester):
                 self.assertLess(abs(x - y), 2)
 
     def test_premultiply(self):
-        for fmt in unsigned_formats + [pyvips.BandFormat.SHORT, 
+        for fmt in unsigned_formats + [pyvips.BandFormat.SHORT,
                 pyvips.BandFormat.INT] + float_formats:
             mx = 255
             alpha = mx / 2.0
@@ -330,7 +331,7 @@ class TestConversion(PyvipsTester):
                 self.assertLess(abs(x - y), 2)
 
     def test_unpremultiply(self):
-        for fmt in unsigned_formats + [pyvips.BandFormat.SHORT, 
+        for fmt in unsigned_formats + [pyvips.BandFormat.SHORT,
                 pyvips.BandFormat.INT] + float_formats:
             mx = 255
             alpha = mx / 2.0
@@ -446,7 +447,7 @@ class TestConversion(PyvipsTester):
                 cp = test(10, 10)
                 tp = t(10, 10) * 3
                 ep = e(10, 10) * 3
-                predict = [te if ce != 0 else ee 
+                predict = [te if ce != 0 else ee
                            for ce, te, ee in zip(cp, tp, ep)]
                 result = r(10, 10)
                 self.assertAlmostEqualObjects(result, predict)
@@ -454,7 +455,7 @@ class TestConversion(PyvipsTester):
                 cp = test(50, 50)
                 tp = t(50, 50) * 3
                 ep = e(50, 50) * 3
-                predict = [te if ce != 0 else ee 
+                predict = [te if ce != 0 else ee
                            for ce, te, ee in zip(cp, tp, ep)]
                 result = r(50, 50)
                 self.assertAlmostEqualObjects(result, predict)
@@ -552,7 +553,7 @@ class TestConversion(PyvipsTester):
         self.assertEqual(im.bands, max_bands)
 
         im = pyvips.Image.arrayjoin(self.all_images, shim = 10)
-        self.assertEqual(im.width, max_width * len(self.all_images) + 
+        self.assertEqual(im.width, max_width * len(self.all_images) +
                          10 * (len(self.all_images) - 1))
         self.assertEqual(im.height, max_height)
         self.assertEqual(im.bands, max_bands)

--- a/pyvips/tests/test_convolution.py
+++ b/pyvips/tests/test_convolution.py
@@ -1,6 +1,8 @@
 # vim: set fileencoding=utf-8 :
 
-from helpers import * 
+import operator
+from functools import reduce
+from .helpers import *
 
 # point convolution
 def conv(image, mask, x_position, y_position):
@@ -33,17 +35,17 @@ class TestConvolution(PyvipsTester):
         self.mono = self.colour.extract_band(1)
         self.mono = self.mono.copy(interpretation = pyvips.Interpretation.B_W)
         self.all_images = [self.mono, self.colour]
-        self.sharp = pyvips.Image.new_from_array([[-1, -1,  -1], 
-                                                [-1,  16, -1], 
+        self.sharp = pyvips.Image.new_from_array([[-1, -1,  -1],
+                                                [-1,  16, -1],
                                                 [-1, -1,  -1]], scale = 8)
-        self.blur = pyvips.Image.new_from_array([[1, 1, 1], 
-                                               [1, 1, 1], 
+        self.blur = pyvips.Image.new_from_array([[1, 1, 1],
+                                               [1, 1, 1],
                                                [1, 1, 1]], scale = 9)
-        self.line = pyvips.Image.new_from_array([[ 1,  1,  1], 
-                                               [-2, -2, -2], 
+        self.line = pyvips.Image.new_from_array([[ 1,  1,  1],
+                                               [-2, -2, -2],
                                                [ 1,  1,  1]])
-        self.sobel = pyvips.Image.new_from_array([[ 1,  2,  1], 
-                                                [ 0,  0,  0], 
+        self.sobel = pyvips.Image.new_from_array([[ 1,  2,  1],
+                                                [ 0,  0,  0],
                                                 [-1, -2, -1]])
         self.all_masks = [self.sharp, self.blur, self.line, self.sobel]
 
@@ -86,8 +88,8 @@ class TestConvolution(PyvipsTester):
             for msk in self.all_masks:
                 for prec in [pyvips.Precision.INTEGER, pyvips.Precision.FLOAT]:
                     for times in range(1, 4):
-                        convolved = im.compass(msk, 
-                                               times = times, 
+                        convolved = im.compass(msk,
+                                               times = times,
                                                angle = pyvips.Angle45.D45,
                                                combine = pyvips.Combine.MAX,
                                                precision = prec)
@@ -100,8 +102,8 @@ class TestConvolution(PyvipsTester):
             for msk in self.all_masks:
                 for prec in [pyvips.Precision.INTEGER, pyvips.Precision.FLOAT]:
                     for times in range(1, 4):
-                        convolved = im.compass(msk, 
-                                               times = times, 
+                        convolved = im.compass(msk,
+                                               times = times,
                                                angle = pyvips.Angle45.D45,
                                                combine = pyvips.Combine.SUM,
                                                precision = prec)
@@ -113,9 +115,9 @@ class TestConvolution(PyvipsTester):
     def test_convsep(self):
         for im in self.all_images:
             for prec in [pyvips.Precision.INTEGER, pyvips.Precision.FLOAT]:
-                gmask = pyvips.Image.gaussmat(2, 0.1, 
+                gmask = pyvips.Image.gaussmat(2, 0.1,
                                             precision = prec)
-                gmask_sep = pyvips.Image.gaussmat(2, 0.1, 
+                gmask_sep = pyvips.Image.gaussmat(2, 0.1,
                                                 separable = True,
                                                 precision = prec)
 
@@ -158,7 +160,7 @@ class TestConvolution(PyvipsTester):
             for prec in [pyvips.Precision.INTEGER, pyvips.Precision.FLOAT]:
                 for i in range(5, 10):
                     sigma = i / 5.0
-                    gmask = pyvips.Image.gaussmat(sigma, 0.2, 
+                    gmask = pyvips.Image.gaussmat(sigma, 0.2,
                                                 precision = prec)
 
                     a = im.conv(gmask, precision = prec)

--- a/pyvips/tests/test_create.py
+++ b/pyvips/tests/test_create.py
@@ -1,6 +1,6 @@
 # vim: set fileencoding=utf-8 :
 
-from helpers import * 
+from .helpers import *
 
 class TestCreate(PyvipsTester):
     def test_black(self):

--- a/pyvips/tests/test_draw.py
+++ b/pyvips/tests/test_draw.py
@@ -1,6 +1,6 @@
 # vim: set fileencoding=utf-8 :
 
-from helpers import * 
+from .helpers import *
 
 class TestDraw(PyvipsTester):
 

--- a/pyvips/tests/test_foreign.py
+++ b/pyvips/tests/test_foreign.py
@@ -1,6 +1,7 @@
 # vim: set fileencoding=utf-8 :
 
-from helpers import *
+import shutil
+from .helpers import *
 
 class TestForeign(PyvipsTester):
 
@@ -74,7 +75,7 @@ class TestForeign(PyvipsTester):
         filename = temp_filename(suf)
 
         buf = pyvips.Operation.call(saver, im)
-        f = open(filename, 'w')
+        f = open(filename, 'wb')
         f.write(buf)
         f.close()
 

--- a/pyvips/tests/test_gvalue.py
+++ b/pyvips/tests/test_gvalue.py
@@ -1,8 +1,11 @@
 # vim: set fileencoding=utf-8 :
 
-from helpers import *
+from .helpers import *
 
 class TestGValue(PyvipsTester):
+    def type_from_name(self, name):
+        return pyvips.gobject_lib.g_type_from_name(name.encode())
+
     def test_bool(self):
         gv = pyvips.GValue()
         gv.init(pyvips.GValue.gbool_type)
@@ -32,8 +35,7 @@ class TestGValue(PyvipsTester):
         # the Interpretation enum is created when the first image is made --
         # make it ourselves in case we are run before the first image
         pyvips.vips_lib.vips_interpretation_get_type()
-        interpretation_gtype = pyvips.gobject_lib. \
-            g_type_from_name('VipsInterpretation')
+        interpretation_gtype = self.type_from_name('VipsInterpretation')
         gv = pyvips.GValue()
         gv.init(interpretation_gtype)
         gv.set('xyz')
@@ -44,8 +46,7 @@ class TestGValue(PyvipsTester):
         # the OperationFlags enum is created when the first op is made --
         # make it ourselves in case we are run before that
         pyvips.vips_lib.vips_operation_flags_get_type()
-        operationflags_gtype = pyvips.gobject_lib. \
-            g_type_from_name('VipsOperationFlags')
+        operationflags_gtype = self.type_from_name('VipsOperationFlags')
         gv = pyvips.GValue()
         gv.init(operationflags_gtype)
         gv.set(12)

--- a/pyvips/tests/test_histogram.py
+++ b/pyvips/tests/test_histogram.py
@@ -1,6 +1,6 @@
 # vim: set fileencoding=utf-8 :
 
-from helpers import *
+from .helpers import *
 
 class TestHistogram(PyvipsTester):
 

--- a/pyvips/tests/test_iofuncs.py
+++ b/pyvips/tests/test_iofuncs.py
@@ -1,6 +1,6 @@
 # vim: set fileencoding=utf-8 :
 
-from helpers import *
+from .helpers import *
 
 class TestIofuncs(PyvipsTester):
 

--- a/pyvips/tests/test_morphology.py
+++ b/pyvips/tests/test_morphology.py
@@ -1,6 +1,6 @@
 # vim: set fileencoding=utf-8 :
 
-from helpers import *
+from .helpers import *
 
 class TestMorphology(PyvipsTester):
 

--- a/pyvips/tests/test_resample.py
+++ b/pyvips/tests/test_resample.py
@@ -1,6 +1,6 @@
 # vim: set fileencoding=utf-8 :
 
-from helpers import *
+from .helpers import *
 
 # Run a function expecting a complex image on a two-band image
 def run_cmplx(fn, image):
@@ -126,7 +126,7 @@ class TestResample(PyvipsTester):
         self.assertEqual(im2.height, round(im.height / 4.0))
 
         # test geometry rounding corner case
-        im = pyvips.Image.black(100, 1);
+        im = pyvips.Image.black(100, 1)
         x = im.resize(0.5)
         self.assertEqual(x.width, 50)
         self.assertEqual(x.height, 1)

--- a/pyvips/vimage.py
+++ b/pyvips/vimage.py
@@ -61,6 +61,16 @@ def _is_2D(array):
 
     return True
 
+# https://stackoverflow.com/a/22409540/1480019
+def with_metaclass(mcls):
+    def decorator(cls):
+        body = vars(cls).copy()
+        # clean out class body
+        body.pop('__dict__', None)
+        body.pop('__weakref__', None)
+        return mcls(cls.__name__, cls.__bases__, body)
+    return decorator
+
 # apply a function to a thing, or map over a list
 # we often need to do something like (1.0 / other) and need to work for lists
 # as well as scalars
@@ -120,9 +130,8 @@ class ImageType(type):
 
         return call_function
 
+@with_metaclass(ImageType)
 class Image(VipsObject):
-    __metaclass__ = ImageType
-
     # private static
 
     @staticmethod
@@ -143,14 +152,15 @@ class Image(VipsObject):
 
     @staticmethod
     def new_from_file(vips_filename, **kwargs):
+        vips_filename = vips_filename.encode()
         filename = vips_lib.vips_filename_get_filename(vips_filename)
         options = vips_lib.vips_filename_get_options(vips_filename)
         name = vips_lib.vips_foreign_find_load(filename)
         if name == ffi.NULL:
             raise Error('unable to load from file {0}'.format(vips_filename))
 
-        return Operation.call(ffi.string(name), ffi.string(filename), 
-                              string_options = ffi.string(options), **kwargs)
+        return Operation.call(ffi.string(name).decode('utf-8'), ffi.string(filename).decode('utf-8'),
+                              string_options = ffi.string(options).decode('utf-8'), **kwargs)
 
     @staticmethod
     def new_from_buffer(data, options, **kwargs):
@@ -158,7 +168,7 @@ class Image(VipsObject):
         if name == ffi.NULL:
             raise Error('unable to load from buffer')
 
-        return Operation.call(ffi.string(name), data, 
+        return Operation.call(ffi.string(name).decode('utf-8'), data,
                               string_options = options, **kwargs)
 
     @staticmethod
@@ -187,7 +197,7 @@ class Image(VipsObject):
 
     @staticmethod
     def new_temp_file(format):
-        vi = vips_lib.vips_image_new_temp_file(format)
+        vi = vips_lib.vips_image_new_temp_file(format.encode())
         if vi == ffi.NULL:
             raise Error('unable to make temp file')
 
@@ -215,23 +225,25 @@ class Image(VipsObject):
     # writers
 
     def write_to_file(self, vips_filename, **kwargs):
+        vips_filename = vips_filename.encode()
         filename = vips_lib.vips_filename_get_filename(vips_filename)
         options = vips_lib.vips_filename_get_options(vips_filename)
         name = vips_lib.vips_foreign_find_save(filename)
         if name == ffi.NULL:
             raise Error('unable to write to file {0}'.format(vips_filename))
 
-        return Operation.call(ffi.string(name), self, filename,
-                              string_options = ffi.string(options), **kwargs)
+        return Operation.call(ffi.string(name).decode('utf-8'), self, filename,
+                              string_options = ffi.string(options).decode('utf-8'), **kwargs)
 
     def write_to_buffer(self, format_string, **kwargs):
+        format_string = format_string.encode()
         options = vips_lib.vips_filename_get_options(format_string)
         name = vips_lib.vips_foreign_find_save_buffer(format_string)
         if name == ffi.NULL:
             raise Error('unable to write to buffer')
 
-        return Operation.call(ffi.string(name), self, 
-                              string_options = ffi.string(options), **kwargs)
+        return Operation.call(ffi.string(name).decode('utf-8'), self,
+                              string_options = ffi.string(options).decode('utf-8'), **kwargs)
 
     def write(self, other):
         result = vips_lib.vips_image_write(self.pointer, other.pointer)
@@ -241,11 +253,11 @@ class Image(VipsObject):
     # get/set metadata
 
     def get_typeof(self, name):
-        return vips_lib.vips_image_get_typeof(self.pointer, name)
+        return vips_lib.vips_image_get_typeof(self.pointer, name.encode())
 
     def get(self, name):
         gv = GValue()
-        result = vips_lib.vips_image_get(self.pointer, name, gv.pointer)
+        result = vips_lib.vips_image_get(self.pointer, name.encode(), gv.pointer)
         if result != 0:
             raise Error('unable to get {0}'.format(name))
 
@@ -255,14 +267,14 @@ class Image(VipsObject):
         gv = GValue()
         gv.init(gtype)
         gv.set(value)
-        vips_lib.vips_image_set(self.pointer, name, gv.pointer)
+        vips_lib.vips_image_set(self.pointer, name.encode(), gv.pointer)
 
     def set(self, name, value):
         gtype = self.get_typeof(name)
         self.set_type(gtype, name, value)
 
     def remove(self, name):
-        return vips_lib.vips_image_remove(self.pointer, name) != 0
+        return vips_lib.vips_image_remove(self.pointer, name.encode()) != 0
 
     def __getattr__(self, name):
         # logger.debug('Image.__getattr__ {0}'.format(name))

--- a/pyvips/vinterpolate.py
+++ b/pyvips/vinterpolate.py
@@ -29,7 +29,7 @@ class Interpolate(VipsObject):
     def new(name):
         # logger.debug('VipsInterpolate.new: name = {0}'.format(name))
 
-        vi = vips_lib.vips_interpolate_new(name)
+        vi = vips_lib.vips_interpolate_new(name.encode())
         if vi == ffi.NULL:
             raise Error('no such interpolator {0}'.format(name))
 

--- a/pyvips/vobject.py
+++ b/pyvips/vobject.py
@@ -84,11 +84,11 @@ class VipsObject(GObject):
         # logger.debug('VipsObject.get_typeof: self = {0}, name = {1}'.
         #              format(self, name))
 
-        pspec = ffi.new('GParamSpec **');
-        argument_class = ffi.new('VipsArgumentClass **');
-        argument_instance = ffi.new('VipsArgumentInstance **');
+        pspec = ffi.new('GParamSpec **')
+        argument_class = ffi.new('VipsArgumentClass **')
+        argument_instance = ffi.new('VipsArgumentInstance **')
         vo = ffi.cast('VipsObject *', self.pointer)
-        result = vips_lib.vips_object_get_argument(vo, name,
+        result = vips_lib.vips_object_get_argument(vo, name.encode(),
             pspec, argument_class, argument_instance)
 
         if result != 0:
@@ -106,7 +106,7 @@ class VipsObject(GObject):
         gv = GValue()
         gv.init(gtype)
         go = ffi.cast('GObject *', self.pointer)
-        gobject_lib.g_object_get_property(go, name, gv.pointer)
+        gobject_lib.g_object_get_property(go, name.encode(), gv.pointer)
 
         return gv.get()
 
@@ -120,7 +120,7 @@ class VipsObject(GObject):
         gv.init(gtype)
         gv.set(value)
         go = ffi.cast('GObject *', self.pointer)
-        gobject_lib.g_object_set_property(go, name, gv.pointer)
+        gobject_lib.g_object_set_property(go, name.encode(), gv.pointer)
 
     # set a series of options using a string, perhaps 'fred=12, tile'
     def set_string(self, string_options):

--- a/pyvips/voperation.py
+++ b/pyvips/voperation.py
@@ -91,7 +91,7 @@ class Operation(VipsObject):
         def add_construct(self, pspec, argument_class, argument_instance, a, b):
             flags = argument_class.flags
             if (flags & _CONSTRUCT) != 0:
-                name = ffi.string(pspec.name)
+                name = ffi.string(pspec.name).decode('utf-8')
 
                 # libvips uses '-' to separate parts of arg names, but we
                 # need '_' for Python
@@ -121,7 +121,7 @@ class Operation(VipsObject):
         logger.debug('VipsOperation.call: string_options = {0}'.
             format(string_options))
 
-        vop = vips_lib.vips_operation_new(operation_name)
+        vop = vips_lib.vips_operation_new(operation_name.encode())
         if vop == ffi.NULL:
             raise Error('no such operation {0}'.format(operation_name))
         op = Operation(vop)
@@ -159,7 +159,7 @@ class Operation(VipsObject):
 
         # set any string options before any args so they can't be
         # overridden
-        if not op.set_string(string_options):
+        if not op.set_string(string_options.encode()):
             raise Error('unable to call {0}'.format(operation_name))
 
         # set required and optional args


### PR DESCRIPTION
Python 2.7.5:
```bash
nosetests --logging-level=WARNING
..............................................................................................................................................................................................
----------------------------------------------------------------------
Ran 190 tests in 38.668s

OK
memory: high-water mark 126.94 MB
````

Python 3.6.2:
```bash
python3.6 -m "nose" --logging-level=WARNING
..............................................................................................................................................................................................
----------------------------------------------------------------------
Ran 190 tests in 38.750s

OK
memory: high-water mark 126.94 MB
````
