### PR TITLE
Windows support (WIP)

### DIFF
--- a/examples/cod.py
+++ b/examples/cod.py
@@ -2,11 +2,10 @@
 
 import sys
 
-import logging
-# logging.basicConfig(level = logging.DEBUG)
-
 import pyvips
 
+# import logging
+# logging.basicConfig(level = logging.DEBUG)
 # pyvips.cache_set_trace(True)
 
 

--- a/examples/read_profile.py
+++ b/examples/read_profile.py
@@ -2,11 +2,10 @@
 
 import sys
 
-# import logging
-# logging.basicConfig(level = logging.DEBUG)
-
 import pyvips
 
+# import logging
+# logging.basicConfig(level = logging.DEBUG)
 # pyvips.cache_set_trace(True)
 
 a = pyvips.Image.new_from_file(sys.argv[1])

--- a/examples/try1.py
+++ b/examples/try1.py
@@ -2,18 +2,17 @@
 
 import pyvips
 
-print 'test Image'
+print('test Image')
 image = pyvips.Image.new_from_file('/home/john/pics/k2.jpg')
-print 'image =', image
-print 'image.width =', image.width
-print ''
+print('image =', image)
+print('image.width =', image.width)
+print('\n''')
 
-print 'test Operation'
+print('test Operation')
 image2 = pyvips.Operation.call('embed', image, 1, 2, 3, 4, extend='copy')
-print 'image2 =', image2
-print ''
-
-print 'test getattr'
+print('image2 =', image2)
+print('\n''')
+print('test getattr')
 image2 = image.embed(1, 2, 3, 4, extend='copy')
-print 'image2 =', image2
-print ''
+print('image2 =', image2)
+print('\n''')

--- a/examples/try10.py
+++ b/examples/try10.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python
 
-import sys
-
-import logging
+# import logging
 # logging.basicConfig(level = logging.DEBUG)
 
 import pyvips

--- a/examples/try11.py
+++ b/examples/try11.py
@@ -2,16 +2,16 @@
 
 import sys
 
+import pyvips
+
 # import logging
 # logging.basicConfig(level = logging.DEBUG)
-
-import pyvips
 
 a = pyvips.Image.new_from_file(sys.argv[1])
 
 ipct = a.get("ipct-data")
 
-print "ipct = ", ipct.get()
+print("ipct = ", ipct.get())
 
 a.remove("ipct-data")
 

--- a/examples/try13.py
+++ b/examples/try13.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-import sys
+# import pyvips
 import logging
-import pyvips
 
 logging.basicConfig(level=logging.DEBUG)

--- a/examples/try14.py
+++ b/examples/try14.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python
 
-import sys
-
-import logging
+# import logging
 # logging.basicConfig(level = logging.DEBUG)
 
 import pyvips

--- a/examples/try16.py
+++ b/examples/try16.py
@@ -1,10 +1,12 @@
 #!/usr/bin/python3
 
-import sys
 import logging
+import sys
+
 import pyvips
 
 logging.basicConfig(level=logging.DEBUG)
+
 # pyvips.cache_set_trace(True)
 
 a = pyvips.Image.new_from_file(sys.argv[1])

--- a/examples/try17.py
+++ b/examples/try17.py
@@ -1,11 +1,13 @@
 #!/usr/bin/python3
 
 import sys
-import logging
+
 import pyvips
 
-# pyvips.cache_set_trace(True)
+# import logging
 # logging.basicConfig(level = logging.DEBUG)
+
+# pyvips.cache_set_trace(True)
 
 a = pyvips.Image.new_from_file(sys.argv[1])
 

--- a/examples/try2.py
+++ b/examples/try2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import logging
+
 import pyvips
 
 logging.basicConfig(level=logging.DEBUG)
@@ -8,22 +9,22 @@ pyvips.cache_set_trace(True)
 
 try:
     a = pyvips.Image.new_from_file("/home/john/pics/babe.poop")
-except pyvips.Error, e:
-    print e
+except pyvips.Error as e:
+    print(str(e))
 
 a = pyvips.Image.new_from_file("/home/john/pics/babe.jpg")
 b = pyvips.Image.new_from_file("/home/john/pics/k2.jpg")
 
-print 'a =', a
-print 'b =', b
+print('a =', a)
+print('b =', b)
 
 out = pyvips.call("add", a, b)
 
-print 'out =', out
+print('out =', out)
 
 out = a.add(b)
 
-print 'out =', out
+print('out =', out)
 
 out = out.linear([1, 1, 1], [2, 2, 2])
 

--- a/examples/try3.py
+++ b/examples/try3.py
@@ -1,12 +1,14 @@
 #!/usr/bin/python
 
 import sys
-import pyvips
-# import logging
 
+import pyvips
+
+# import logging
 # logging.basicConfig(level = logging.DEBUG)
+
 pyvips.cache_set_trace(True)
 
 a = pyvips.Image.new_from_file(sys.argv[1])
-print a.max()
-print a.max()
+print(a.max())
+print(a.max())

--- a/examples/try4.py
+++ b/examples/try4.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python
 
 import sys
-import pyvips
-# import logging
 
+import pyvips
+
+# import logging
 # logging.basicConfig(level = logging.DEBUG)
 
 a = pyvips.Image.new_from_file(sys.argv[1])

--- a/examples/try5.py
+++ b/examples/try5.py
@@ -1,23 +1,24 @@
 #!/usr/bin/python
 
 import sys
-# import logging
+
 import pyvips
 
+# import logging
 # logging.basicConfig(level = logging.DEBUG)
+
+a = pyvips.Image.new_from_file(sys.argv[1])
 
 
 def should_equal(test, a, b):
     if abs(a - b) > 0.01:
-        print '%s: seen %g and %g' % (test, a, b)
+        print('%s: seen %g and %g' % (test, a, b))
         sys.exit(1)
 
 
 def bandsplit(a):
     return [a.extract_band(i) for i in range(0, a.bands)]
 
-
-a = pyvips.Image.new_from_file(sys.argv[1])
 
 # test operator overloads
 
@@ -26,11 +27,12 @@ b = a + 12
 should_equal('add constant', a.avg() + 12, b.avg())
 
 b = a + [12, 0, 0]
-x = map(lambda x: x.avg()) bandsplit(a)
-y = map(lambda x: x.avg()) bandsplit(b)
+x = map(lambda x: x.avg())
+bandsplit(a)
+y = map(lambda x: x.avg())
+bandsplit(b)
 x[0] += 12
 should_equal('add multiband constant', sum(x), sum(y))
-
 
 b = a + [12, 0, 0]
 b = a + b

--- a/examples/try6.py
+++ b/examples/try6.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python
 
 import sys
-# import logging
+
 import pyvips
 
+# import logging
 # logging.basicConfig(level = logging.DEBUG)
 
 a = pyvips.Image.new_from_file(sys.argv[1])

--- a/examples/try7.py
+++ b/examples/try7.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python
 
 import sys
-# import logging
+
 import pyvips
 
+# import logging
 # logging.basicConfig(level = logging.DEBUG)
 
 a = pyvips.Image.new_from_file(sys.argv[1])

--- a/examples/try8.py
+++ b/examples/try8.py
@@ -1,14 +1,13 @@
 #!/usr/bin/python
 
-import sys
 # import logging
-import pyvips
-
 # logging.basicConfig(level = logging.DEBUG)
+
+import pyvips
 
 a = pyvips.Image.new_from_array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 8, 128)
 
-print 'scale =', a.get('scale')
-print 'offset =', a.get('offset')
+print('scale =', a.get('scale'))
+print('offset =', a.get('offset'))
 
 a.write_to_file("x.v")

--- a/examples/try9.py
+++ b/examples/try9.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
-import sys
 import logging
+
 import pyvips
 
 logging.basicConfig(level=logging.DEBUG)

--- a/pyvips/__init__.py
+++ b/pyvips/__init__.py
@@ -1,27 +1,14 @@
 # wrapper for libvips
-
-# Our classes need to refer to each other ... make them go via this
-# package-level global which we update at the end with references to the real
-# classes
-package_index = {
-    'Image': 'banana',
-    'Operation': 'apple',
-    'GValue': 'kumquat'
-}
+# flake8: noqa
 
 from .base import *
 from .enums import *
-from .gvalue import GValue
 from .gobject import GObject
+from .gvalue import GValue
 from .vobject import VipsObject
+from .vinterpolate import Interpolate
 from .voperation import Operation
 from .vimage import Image
-from .vinterpolate import Interpolate
-
-package_index['Image'] = Image
-package_index['Operation'] = Operation
-package_index['GValue'] = GValue
 
 __all__ = ['Error', 'Image', 'Operation', 'GValue',
-           'type_find', 'type_name',
-          ]
+           'type_find', 'type_name']

--- a/pyvips/base.py
+++ b/pyvips/base.py
@@ -3,8 +3,9 @@
 from __future__ import division
 
 import logging
-import sys
 import os
+import sys
+
 from cffi import FFI
 
 logger = logging.getLogger(__name__)
@@ -15,16 +16,18 @@ _is_windows = os.name == 'nt'
 
 # possibly use ctypes.util.find_library() to locate the lib
 # need a different name on os x?
-vips_lib = ffi.dlopen('libvips-42.dll' if _is_windows else 'libvips.so')
-gobject_lib = ffi.dlopen('libgobject-2.0-0.dll' if _is_windows else 'libgobject-2.0.so')
+vips_lib = ffi.dlopen('libvips-42.dll' if _is_windows
+                      else 'libvips.so')
+gobject_lib = ffi.dlopen('libgobject-2.0-0.dll' if _is_windows
+                         else 'libgobject-2.0.so')
 
 if _is_windows:
     glib_lib = ffi.dlopen('libglib-2.0-0.dll')
 else:
     glib_lib = gobject_lib
 
-logger.debug('Loaded lib {0}'.format(vips_lib))
-logger.debug('Loaded lib {0}'.format(gobject_lib))
+logger.debug('Loaded lib %s', vips_lib)
+logger.debug('Loaded lib %s', gobject_lib)
 
 _is_PY3 = sys.version_info[0] == 3
 
@@ -33,15 +36,18 @@ if _is_PY3:
 else:
     text_type = unicode
 
+
 def to_bytes(x):
     if isinstance(x, text_type):
         x = x.encode()
     return x
 
+
 def to_string(x):
     if _is_PY3 and isinstance(x, bytes):
         x = x.decode('utf-8')
     return x
+
 
 # apparently the best way to find out
 _is_64bits = sys.maxsize > 2 ** 32
@@ -80,13 +86,15 @@ ffi.cdef('''
 
 ''')
 
+
 class Error(Exception):
     """An error from vips.
 
     message -- a high-level description of the error
     detail -- a string with some detailed diagnostics
     """
-    def __init__(self, message, detail = None):
+
+    def __init__(self, message, detail=None):
         self.message = message
         if detail is None or detail == "":
             detail = to_string(ffi.string(vips_lib.vips_error_buffer()))
@@ -98,30 +106,40 @@ class Error(Exception):
     def __str__(self):
         return '{0}\n  {1}'.format(self.message, self.detail)
 
+
 if vips_lib.vips_init(to_bytes(sys.argv[0])) != 0:
     raise Error('unable to init libvips')
+
 
 def shutdown():
     logger.debug('Shutting down libvips')
     vips_lib.vips_shutdown()
 
+
 logger.debug('Inited libvips')
 logger.debug('')
+
 
 def leak_set(leak):
     return vips_lib.vips_leak_set(leak)
 
+
 def path_filename7(filename):
-    return to_string(ffi.string(vips_lib.vips_path_filename7(to_bytes(filename))))
+    return to_string(ffi.string(vips_lib.vips_path_filename7(
+        to_bytes(filename))))
+
 
 def path_mode7(filename):
     return to_string(ffi.string(vips_lib.vips_path_mode7(to_bytes(filename))))
 
+
 def type_find(basename, nickname):
     return vips_lib.vips_type_find(to_bytes(basename), to_bytes(nickname))
 
+
 def type_name(gtype):
     return to_string(ffi.string(gobject_lib.g_type_name(gtype)))
+
 
 __all__ = ['ffi', 'vips_lib', 'gobject_lib', 'glib_lib', 'Error',
            'leak_set', 'to_bytes', 'to_string', 'type_find',

--- a/pyvips/base.py
+++ b/pyvips/base.py
@@ -4,17 +4,24 @@ from __future__ import division
 
 import logging
 import sys
+import os
 from cffi import FFI
 
 logger = logging.getLogger(__name__)
 
 ffi = FFI()
 
+_is_windows = os.name == 'nt'
+
 # possibly use ctypes.util.find_library() to locate the lib
-# need a different name on windows? or os x?
-# on win, may need to explcitly load other libraries as well
-vips_lib = ffi.dlopen('libvips.so')
-gobject_lib = ffi.dlopen('libgobject-2.0.so')
+# need a different name on os x?
+vips_lib = ffi.dlopen('libvips-42.dll' if _is_windows else 'libvips.so')
+gobject_lib = ffi.dlopen('libgobject-2.0-0.dll' if _is_windows else 'libgobject-2.0.so')
+
+if _is_windows:
+    glib_lib = ffi.dlopen('libglib-2.0-0.dll')
+else:
+    glib_lib = gobject_lib
 
 logger.debug('Loaded lib {0}'.format(vips_lib))
 logger.debug('Loaded lib {0}'.format(gobject_lib))
@@ -116,6 +123,6 @@ def type_find(basename, nickname):
 def type_name(gtype):
     return to_string(ffi.string(gobject_lib.g_type_name(gtype)))
 
-__all__ = ['ffi', 'vips_lib', 'gobject_lib', 'Error', 'leak_set',
-           'to_bytes', 'to_string', 'type_find', 'type_name',
-           'path_filename7', 'path_mode7', 'shutdown']
+__all__ = ['ffi', 'vips_lib', 'gobject_lib', 'glib_lib', 'Error',
+           'leak_set', 'to_bytes', 'to_string', 'type_find',
+           'type_name', 'path_filename7', 'path_mode7', 'shutdown']

--- a/pyvips/enums.py
+++ b/pyvips/enums.py
@@ -6,6 +6,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class BandFormat(object):
     UCHAR = 'uchar'
     CHAR = 'char'
@@ -18,48 +19,53 @@ class BandFormat(object):
     DOUBLE = 'double'
     DPCOMPLEX = 'dpcomplex'
 
+
 class Interpretation(object):
-	MULTIBAND = 'multiband'
-	B_W = 'b-w'
-	HISTOGRAM = 'histogram'
-	XYZ = 'xyz'
-	LAB = 'lab'
-	CMYK = 'cmyk'
-	LABQ = 'labq'
-	RGB = 'rgb'
-	CMC = 'cmc'
-	LCH = 'lch'
-	LABS = 'labs'
-	SRGB = 'srgb'
-	YXY = 'yxy'
-	FOURIER = 'fourier'
-	RGB16 = 'rgb16'
-	GREY16 = 'grey16'
-	MATRIX = 'matrix'
-	SCRGB = 'scrgb'
-	HSV = 'hsv'
+    MULTIBAND = 'multiband'
+    B_W = 'b-w'
+    HISTOGRAM = 'histogram'
+    XYZ = 'xyz'
+    LAB = 'lab'
+    CMYK = 'cmyk'
+    LABQ = 'labq'
+    RGB = 'rgb'
+    CMC = 'cmc'
+    LCH = 'lch'
+    LABS = 'labs'
+    SRGB = 'srgb'
+    YXY = 'yxy'
+    FOURIER = 'fourier'
+    RGB16 = 'rgb16'
+    GREY16 = 'grey16'
+    MATRIX = 'matrix'
+    SCRGB = 'scrgb'
+    HSV = 'hsv'
+
 
 class Angle(object):
-	D0 = 'd0'
-	D90 = 'd90'
-	D180 = 'd180'
-	D270 = 'd270'
+    D0 = 'd0'
+    D90 = 'd90'
+    D180 = 'd180'
+    D270 = 'd270'
+
 
 class Angle45(object):
-	D0 = 'd0'
-	D45 = 'd45'
-	D90 = 'd90'
-	D135 = 'd135'
-	D180 = 'd180'
-	D225 = 'd225'
-	D270 = 'd270'
-	D315 = 'd315'
+    D0 = 'd0'
+    D45 = 'd45'
+    D90 = 'd90'
+    D135 = 'd135'
+    D180 = 'd180'
+    D225 = 'd225'
+    D270 = 'd270'
+    D315 = 'd315'
+
 
 class Intent(object):
-	PERCEPTUAL = 'perceptual'
-	RELATIVE = 'relative'
-	SATURATION = 'saturation'
-	ABSOLUTE = 'absolute'
+    PERCEPTUAL = 'perceptual'
+    RELATIVE = 'relative'
+    SATURATION = 'saturation'
+    ABSOLUTE = 'absolute'
+
 
 class Extend(object):
     BLACK = 'black'
@@ -69,30 +75,35 @@ class Extend(object):
     WHITE = 'white'
     BACKGROUND = 'background'
 
+
 class Precision(object):
-	INTEGER = 'integer'
-	FLOAT = 'float'
-	APPROXIMATE = 'approximate'
+    INTEGER = 'integer'
+    FLOAT = 'float'
+    APPROXIMATE = 'approximate'
+
 
 class Coding(object):
-	NONE = 'none'
-	LABQ = 'labq'
-	RAD = 'rad'
+    NONE = 'none'
+    LABQ = 'labq'
+    RAD = 'rad'
+
 
 class Direction(object):
-	HORIZONTAL = 'horizontal'
-	VERTICAL = 'vertical'
+    HORIZONTAL = 'horizontal'
+    VERTICAL = 'vertical'
+
 
 class Align(object):
-	LOW = 'low'
-	CENTRE = 'centre'
-	HIGH = 'high'
+    LOW = 'low'
+    CENTRE = 'centre'
+    HIGH = 'high'
+
 
 class Combine(object):
-	MAX = 'max'
-	SUM = 'sum'
+    MAX = 'max'
+    SUM = 'sum'
+
 
 class PCS(object):
-	LAB = 'lab'
-	XYZ = 'xyz'
-
+    LAB = 'lab'
+    XYZ = 'xyz'

--- a/pyvips/gobject.py
+++ b/pyvips/gobject.py
@@ -2,9 +2,10 @@
 
 from __future__ import division
 
+import gc
 import logging
 
-from pyvips import *
+from pyvips import ffi, vips_lib, gobject_lib
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ ffi.cdef('''
     typedef struct _GParamSpec {
         void* g_type_instance;
 
-        const char* name;     
+        const char* name;
         unsigned int flags;
         GType value_type;
         GType owner_type;
@@ -29,23 +30,23 @@ ffi.cdef('''
     void g_object_ref (void* object);
     void g_object_unref (void* object);
 
-    void g_object_set_property (GObject* object, 
+    void g_object_set_property (GObject* object,
         const char *name, GValue* value);
-    void g_object_get_property (GObject* object, 
+    void g_object_get_property (GObject* object,
         const char* name, GValue* value);
 
 ''')
 
-class GObject(object):
 
+class GObject(object):
     def __init__(self, pointer):
         # record the pointer we were given to manage
         self.pointer = pointer
-        # logger.debug('GObject.__init__: pointer = {0}'.format(self.pointer))
+        # logger.debug('GObject.__init__: pointer = %s', str(self.pointer))
 
         # on GC, unref
         self.gobject = ffi.gc(self.pointer, gobject_lib.g_object_unref)
-        # logger.debug('GObject.__init__: gobject = {0}'.format(self.gobject))
+        # logger.debug('GObject.__init__: gobject = %s', str(self.gobject))
 
     @staticmethod
     def print_all(msg):
@@ -53,5 +54,6 @@ class GObject(object):
         print(msg)
         vips_lib.vips_object_print_all()
         print()
+
 
 __all__ = ['GObject']

--- a/pyvips/gvalue.py
+++ b/pyvips/gvalue.py
@@ -139,16 +139,16 @@ class GValue(object):
             vips_lib.vips_value_set_array_image(self.gvalue, len(value))
             array = vips_lib.vips_value_get_array_image(self.gvalue, ffi.NULL)
             for i, image in enumerate(value):
-                vips_lib.g_object_ref(image.pointer)
+                gobject_lib.g_object_ref(image.pointer)
                 array[i] = image.pointer
         elif gtype == GValue.blob_type:
             # we need to set the blob to a copy of the string that vips_lib
             # can own
-            memory = gobject_lib.g_malloc(len(value))
+            memory = glib_lib.g_malloc(len(value))
             ffi.memmove(memory, value, len(value))
 
-            vips_lib.vips_value_set_blob(self.gvalue, 
-                    gobject_lib.g_free, memory, len(value))
+            vips_lib.vips_value_set_blob(self.gvalue,
+                    glib_lib.g_free, memory, len(value))
         else:
             raise Error('unsupported gtype for set {0}, fundamental {1}'.
                         format(type_name(gtype), type_name(fundamental)))
@@ -219,7 +219,7 @@ class GValue(object):
             result = []
             for i in range(0, pint[0]):
                 vi = array[i]
-                vips_lib.g_object_ref(vi)
+                gobject_lib.g_object_ref(vi)
                 image = package_index['Image'](vi)
                 result.append(image)
         elif gtype == GValue.blob_type:

--- a/pyvips/tests/helpers.py
+++ b/pyvips/tests/helpers.py
@@ -1,10 +1,10 @@
 # vim: set fileencoding=utf-8 :
 # test helpers
-
 from __future__ import division
+
 import os
-import unittest
 import tempfile
+import unittest
 
 import pyvips
 
@@ -14,7 +14,8 @@ IMAGES = os.path.join(os.path.dirname(__file__), 'images')
 JPEG_FILE = os.path.join(IMAGES, "йцук.jpg")
 SRGB_FILE = os.path.join(IMAGES, "sRGB.icm")
 
-TEST_IMAGES = os.path.join(os.path.dirname(__file__), '..', '..', 'test_images')
+TEST_IMAGES = os.path.join(os.path.dirname(__file__),
+                           '..', '..', 'test_images')
 MATLAB_FILE = os.path.join(TEST_IMAGES, "sample.mat")
 PNG_FILE = os.path.join(TEST_IMAGES, "sample.png")
 TIF_FILE = os.path.join(TEST_IMAGES, "sample.tif")
@@ -33,16 +34,16 @@ SVG_GZ_FILE = os.path.join(TEST_IMAGES, "vips-profile.svg.gz")
 GIF_ANIM_FILE = os.path.join(TEST_IMAGES, "cogs.gif")
 DICOM_FILE = os.path.join(TEST_IMAGES, "dicom_test_image.dcm")
 
-unsigned_formats = [pyvips.BandFormat.UCHAR, 
-                    pyvips.BandFormat.USHORT, 
-                    pyvips.BandFormat.UINT] 
-signed_formats = [pyvips.BandFormat.CHAR, 
-                  pyvips.BandFormat.SHORT, 
-                  pyvips.BandFormat.INT] 
-float_formats = [pyvips.BandFormat.FLOAT, 
+unsigned_formats = [pyvips.BandFormat.UCHAR,
+                    pyvips.BandFormat.USHORT,
+                    pyvips.BandFormat.UINT]
+signed_formats = [pyvips.BandFormat.CHAR,
+                  pyvips.BandFormat.SHORT,
+                  pyvips.BandFormat.INT]
+float_formats = [pyvips.BandFormat.FLOAT,
                  pyvips.BandFormat.DOUBLE]
-complex_formats = [pyvips.BandFormat.COMPLEX, 
-                   pyvips.BandFormat.DPCOMPLEX] 
+complex_formats = [pyvips.BandFormat.COMPLEX,
+                   pyvips.BandFormat.DPCOMPLEX]
 int_formats = unsigned_formats + signed_formats
 noncomplex_formats = int_formats + float_formats
 all_formats = int_formats + float_formats + complex_formats
@@ -61,13 +62,13 @@ mono_colourspaces = [pyvips.Interpretation.B_W]
 sixteenbit_colourspaces = [pyvips.Interpretation.GREY16,
                            pyvips.Interpretation.RGB16]
 all_colourspaces = colour_colourspaces + mono_colourspaces + \
-                    coded_colourspaces + sixteenbit_colourspaces
+                   coded_colourspaces + sixteenbit_colourspaces
 
 max_value = {pyvips.BandFormat.UCHAR: 0xff,
              pyvips.BandFormat.USHORT: 0xffff,
-             pyvips.BandFormat.UINT: 0xffffffff, 
+             pyvips.BandFormat.UINT: 0xffffffff,
              pyvips.BandFormat.CHAR: 0x7f,
-             pyvips.BandFormat.SHORT: 0x7fff, 
+             pyvips.BandFormat.SHORT: 0x7fff,
              pyvips.BandFormat.INT: 0x7fffffff,
              pyvips.BandFormat.FLOAT: 1.0,
              pyvips.BandFormat.DOUBLE: 1.0,
@@ -113,8 +114,9 @@ rot_angle_bonds = [pyvips.Angle.D0,
                    pyvips.Angle.D180,
                    pyvips.Angle.D90]
 
+
 # an expanding zip ... if either of the args is a scalar or a one-element list,
-# duplicate it down the other side 
+# duplicate it down the other side
 def zip_expand(x, y):
     # handle singleton list case
     if isinstance(x, list) and len(x) == 1:
@@ -131,13 +133,15 @@ def zip_expand(x, y):
     else:
         return [[x, y]]
 
-# run a 1-ary function on a thing -- loop over elements if the 
+
+# run a 1-ary function on a thing -- loop over elements if the
 # thing is a list
 def run_fn(fn, x):
     if isinstance(x, list):
         return [fn(i) for i in x]
     else:
         return fn(x)
+
 
 # make a temp filename with the specified suffix
 def temp_filename(suffix):
@@ -147,7 +151,8 @@ def temp_filename(suffix):
 
     return filename
 
-# run a 2-ary function on two things -- loop over elements pairwise if the 
+
+# run a 2-ary function on two things -- loop over elements pairwise if the
 # things are lists
 def run_fn2(fn, x, y):
     if isinstance(x, pyvips.Image) or isinstance(y, pyvips.Image):
@@ -157,18 +162,19 @@ def run_fn2(fn, x, y):
     else:
         return fn(x, y)
 
+
 class PyvipsTester(unittest.TestCase):
     # test a pair of things which can be lists for approx. equality
-    def assertAlmostEqualObjects(self, a, b, places = 4, msg = ''):
+    def assertAlmostEqualObjects(self, a, b, places=4, msg=''):
         # print 'assertAlmostEqualObjects %s = %s' % (a, b)
         for x, y in zip_expand(a, b):
-            self.assertAlmostEqual(x, y, places = places, msg = msg)
+            self.assertAlmostEqual(x, y, places=places, msg=msg)
 
     # test a pair of things which can be lists for equality
-    def assertEqualObjects(self, a, b, places = 4, msg = ''):
+    def assertEqualObjects(self, a, b, places=4, msg=''):
         # print 'assertEqualObjects %s = %s' % (a, b)
         for x, y in zip_expand(a, b):
-            self.assertEqual(x, y, msg = msg)
+            self.assertEqual(x, y, msg=msg)
 
     # test a pair of things which can be lists for difference less than a
     # threshold
@@ -176,16 +182,16 @@ class PyvipsTester(unittest.TestCase):
         for x, y in zip_expand(a, b):
             self.assertLess(abs(x - y), diff)
 
-    # run a function on an image and on a single pixel, the results 
-    # should match 
+    # run a function on an image and on a single pixel, the results
+    # should match
     def run_cmp(self, message, im, x, y, fn):
         a = im(x, y)
         v1 = fn(a)
         im2 = fn(im)
         v2 = im2(x, y)
-        self.assertAlmostEqualObjects(v1, v2, msg = message)
+        self.assertAlmostEqualObjects(v1, v2, msg=message)
 
-    # run a function on an image, 
+    # run a function on an image,
     # 50,50 and 10,10 should have different values on the test image
     def run_image(self, message, im, fn):
         self.run_cmp(message, im, 50, 50, fn)
@@ -199,21 +205,20 @@ class PyvipsTester(unittest.TestCase):
         self.run_cmp(message, im, 10, 10, lambda x: run_fn2(fn, x, c))
         self.run_cmp(message, im, 10, 10, lambda x: run_fn2(fn, c, x))
 
-    # run a function on a pair of images and on a pair of pixels, the results 
-    # should match 
+    # run a function on a pair of images and on a pair of pixels, the results
+    # should match
     def run_cmp2(self, message, left, right, x, y, fn):
         a = left(x, y)
         b = right(x, y)
         v1 = fn(a, b)
         after = fn(left, right)
         v2 = after(x, y)
-        self.assertAlmostEqualObjects(v1, v2, msg = message)
+        self.assertAlmostEqualObjects(v1, v2, msg=message)
 
     # run a function on a pair of images
     # 50,50 and 10,10 should have different values on the test image
     def run_image2(self, message, left, right, fn):
-        self.run_cmp2(message, left, right, 50, 50, 
+        self.run_cmp2(message, left, right, 50, 50,
                       lambda x, y: run_fn2(fn, x, y))
-        self.run_cmp2(message, left, right, 10, 10, 
+        self.run_cmp2(message, left, right, 10, 10,
                       lambda x, y: run_fn2(fn, x, y))
-

--- a/pyvips/tests/test_arithmetic.py
+++ b/pyvips/tests/test_arithmetic.py
@@ -1,33 +1,37 @@
 # vim: set fileencoding=utf-8 :
-
 import math
-from .helpers import *
+import unittest
+
+import pyvips
+from .helpers import PyvipsTester, unsigned_formats, \
+    float_formats, noncomplex_formats, all_formats, run_fn
+
 
 class TestArithmetic(PyvipsTester):
-    def run_arith(self, fn, fmt = all_formats):
+    def run_arith(self, fn, fmt=all_formats):
         [self.run_image2(fn.__name__ + ' image', x.cast(y), x.cast(z), fn)
          for x in self.all_images for y in fmt for z in fmt]
 
-    def run_arith_const(self, fn, fmt = all_formats):
+    def run_arith_const(self, fn, fmt=all_formats):
         [self.run_const(fn.__name__ + ' scalar', fn, x.cast(y), 2)
          for x in self.all_images for y in fmt]
-        [self.run_const(fn.__name__ + ' vector', fn, self.colour.cast(y), 
+        [self.run_const(fn.__name__ + ' vector', fn, self.colour.cast(y),
                         [1, 2, 3])
          for y in fmt]
 
-    # run a function on an image, 
+    # run a function on an image,
     # 50,50 and 10,10 should have different values on the test image
     def run_imageunary(self, message, im, fn):
         self.run_cmp(message, im, 50, 50, lambda x: run_fn(fn, x))
         self.run_cmp(message, im, 10, 10, lambda x: run_fn(fn, x))
 
-    def run_unary(self, images, fn, fmt = all_formats):
+    def run_unary(self, images, fn, fmt=all_formats):
         [self.run_imageunary(fn.__name__ + ' image', x.cast(y), fn)
          for x in images for y in fmt]
 
     def setUp(self):
-        im = pyvips.Image.mask_ideal(100, 100, 0.5, 
-                                     reject = True, optical = True)
+        im = pyvips.Image.mask_ideal(100, 100, 0.5,
+                                     reject=True, optical=True)
         self.colour = im * [1, 2, 3] + [2, 3, 4]
         self.mono = self.colour.extract_band(1)
         self.all_images = [self.mono, self.colour]
@@ -60,7 +64,7 @@ class TestArithmetic(PyvipsTester):
             return x / y
 
         # (const / image) needs (image ** -1), which won't work for complex
-        self.run_arith_const(div, fmt = noncomplex_formats)
+        self.run_arith_const(div, fmt=noncomplex_formats)
         self.run_arith(div)
 
     def test_floordiv(self):
@@ -68,52 +72,52 @@ class TestArithmetic(PyvipsTester):
             return x // y
 
         # (const // image) needs (image ** -1), which won't work for complex
-        self.run_arith_const(my_floordiv, fmt = noncomplex_formats)
-        self.run_arith(my_floordiv, fmt = noncomplex_formats)
+        self.run_arith_const(my_floordiv, fmt=noncomplex_formats)
+        self.run_arith(my_floordiv, fmt=noncomplex_formats)
 
     def test_pow(self):
         def my_pow(x, y):
             return x ** y
 
         # (image ** x) won't work for complex images ... just test non-complex
-        self.run_arith_const(my_pow, fmt = noncomplex_formats)
-        self.run_arith(my_pow, fmt = noncomplex_formats)
+        self.run_arith_const(my_pow, fmt=noncomplex_formats)
+        self.run_arith(my_pow, fmt=noncomplex_formats)
 
     def test_and(self):
         def my_and(x, y):
-            # python doesn't allow bools on float 
+            # python doesn't allow bools on float
             if isinstance(x, float):
                 x = int(x)
             if isinstance(y, float):
                 y = int(y)
             return x & y
 
-        self.run_arith_const(my_and, fmt = noncomplex_formats)
-        self.run_arith(my_and, fmt = noncomplex_formats)
+        self.run_arith_const(my_and, fmt=noncomplex_formats)
+        self.run_arith(my_and, fmt=noncomplex_formats)
 
     def test_or(self):
         def my_or(x, y):
-            # python doesn't allow bools on float 
+            # python doesn't allow bools on float
             if isinstance(x, float):
                 x = int(x)
             if isinstance(y, float):
                 y = int(y)
             return x | y
 
-        self.run_arith_const(my_or, fmt = noncomplex_formats)
-        self.run_arith(my_or, fmt = noncomplex_formats)
+        self.run_arith_const(my_or, fmt=noncomplex_formats)
+        self.run_arith(my_or, fmt=noncomplex_formats)
 
     def test_xor(self):
         def my_xor(x, y):
-            # python doesn't allow bools on float 
+            # python doesn't allow bools on float
             if isinstance(x, float):
                 x = int(x)
             if isinstance(y, float):
                 y = int(y)
             return x ^ y
 
-        self.run_arith_const(my_xor, fmt = noncomplex_formats)
-        self.run_arith(my_xor, fmt = noncomplex_formats)
+        self.run_arith_const(my_xor, fmt=noncomplex_formats)
+        self.run_arith(my_xor, fmt=noncomplex_formats)
 
     def test_more(self):
         def more(x, y):
@@ -208,7 +212,7 @@ class TestArithmetic(PyvipsTester):
             return x << 2
 
         # we don't support constant << image, treat as a unary
-        self.run_unary(self.all_images, my_lshift, fmt = noncomplex_formats)
+        self.run_unary(self.all_images, my_lshift, fmt=noncomplex_formats)
 
     def test_rshift(self):
         def my_rshift(x):
@@ -218,14 +222,14 @@ class TestArithmetic(PyvipsTester):
             return x >> 2
 
         # we don't support constant >> image, treat as a unary
-        self.run_unary(self.all_images, my_rshift, fmt = noncomplex_formats)
+        self.run_unary(self.all_images, my_rshift, fmt=noncomplex_formats)
 
     def test_mod(self):
         def my_mod(x):
             return x % 2
 
         # we don't support constant % image, treat as a unary
-        self.run_unary(self.all_images, my_mod, fmt = noncomplex_formats)
+        self.run_unary(self.all_images, my_mod, fmt=noncomplex_formats)
 
     def test_pos(self):
         def my_pos(x):
@@ -247,24 +251,24 @@ class TestArithmetic(PyvipsTester):
 
         # ~image is trimmed to image max so it's hard to test for all formats
         # just test uchar
-        self.run_unary(self.all_images, my_invert, 
-                       fmt = [pyvips.BandFormat.UCHAR])
+        self.run_unary(self.all_images, my_invert,
+                       fmt=[pyvips.BandFormat.UCHAR])
 
     # test the rest of VipsArithmetic
 
     def test_avg(self):
         im = pyvips.Image.black(50, 100)
-        test = im.insert(im + 100, 50, 0, expand = True)
+        test = im.insert(im + 100, 50, 0, expand=True)
 
         for fmt in all_formats:
             self.assertAlmostEqual(test.cast(fmt).avg(), 50)
 
     def test_deviate(self):
         im = pyvips.Image.black(50, 100)
-        test = im.insert(im + 100, 50, 0, expand = True)
+        test = im.insert(im + 100, 50, 0, expand=True)
 
         for fmt in noncomplex_formats:
-            self.assertAlmostEqual(test.cast(fmt).deviate(), 50, places = 2)
+            self.assertAlmostEqual(test.cast(fmt).deviate(), 50, places=2)
 
     def test_polar(self):
         im = pyvips.Image.black(100, 100) + 100
@@ -295,30 +299,30 @@ class TestArithmetic(PyvipsTester):
 
     def test_histfind(self):
         im = pyvips.Image.black(50, 100)
-        test = im.insert(im + 10, 50, 0, expand = True)
+        test = im.insert(im + 10, 50, 0, expand=True)
 
         for fmt in all_formats:
             hist = test.cast(fmt).hist_find()
-            self.assertAlmostEqualObjects(hist(0,0), [5000])
-            self.assertAlmostEqualObjects(hist(10,0), [5000])
-            self.assertAlmostEqualObjects(hist(5,0), [0])
+            self.assertAlmostEqualObjects(hist(0, 0), [5000])
+            self.assertAlmostEqualObjects(hist(10, 0), [5000])
+            self.assertAlmostEqualObjects(hist(5, 0), [0])
 
         test = test * [1, 2, 3]
 
         for fmt in all_formats:
-            hist = test.cast(fmt).hist_find(band = 0)
-            self.assertAlmostEqualObjects(hist(0,0), [5000])
-            self.assertAlmostEqualObjects(hist(10,0), [5000])
-            self.assertAlmostEqualObjects(hist(5,0), [0])
+            hist = test.cast(fmt).hist_find(band=0)
+            self.assertAlmostEqualObjects(hist(0, 0), [5000])
+            self.assertAlmostEqualObjects(hist(10, 0), [5000])
+            self.assertAlmostEqualObjects(hist(5, 0), [0])
 
-            hist = test.cast(fmt).hist_find(band = 1)
-            self.assertAlmostEqualObjects(hist(0,0), [5000])
-            self.assertAlmostEqualObjects(hist(20,0), [5000])
-            self.assertAlmostEqualObjects(hist(5,0), [0])
+            hist = test.cast(fmt).hist_find(band=1)
+            self.assertAlmostEqualObjects(hist(0, 0), [5000])
+            self.assertAlmostEqualObjects(hist(20, 0), [5000])
+            self.assertAlmostEqualObjects(hist(5, 0), [0])
 
     def test_histfind_indexed(self):
         im = pyvips.Image.black(50, 100)
-        test = im.insert(im + 10, 50, 0, expand = True)
+        test = im.insert(im + 10, 50, 0, expand=True)
         index = test // 10
 
         for x in noncomplex_formats:
@@ -327,8 +331,8 @@ class TestArithmetic(PyvipsTester):
                 b = index.cast(y)
                 hist = a.hist_find_indexed(b)
 
-                self.assertAlmostEqualObjects(hist(0,0), [0])
-                self.assertAlmostEqualObjects(hist(1,0), [50000])
+                self.assertAlmostEqualObjects(hist(0, 0), [0])
+                self.assertAlmostEqualObjects(hist(1, 0), [50000])
 
     def test_histfind_ndim(self):
         im = pyvips.Image.black(100, 100) + [1, 2, 3]
@@ -336,12 +340,12 @@ class TestArithmetic(PyvipsTester):
         for fmt in noncomplex_formats:
             hist = im.cast(fmt).hist_find_ndim()
 
-            self.assertAlmostEqualObjects(hist(0,0)[0], 10000)
-            self.assertAlmostEqualObjects(hist(5,5)[5], 0)
+            self.assertAlmostEqualObjects(hist(0, 0)[0], 10000)
+            self.assertAlmostEqualObjects(hist(5, 5)[5], 0)
 
-            hist = im.cast(fmt).hist_find_ndim(bins = 1)
+            hist = im.cast(fmt).hist_find_ndim(bins=1)
 
-            self.assertAlmostEqualObjects(hist(0,0)[0], 10000)
+            self.assertAlmostEqualObjects(hist(0, 0)[0], 10000)
             self.assertEqual(hist.width, 1)
             self.assertEqual(hist.height, 1)
             self.assertEqual(hist.bands, 1)
@@ -351,7 +355,7 @@ class TestArithmetic(PyvipsTester):
 
         for fmt in all_formats:
             im = test.cast(fmt)
-            hough = im.hough_circle(min_radius = 35, max_radius = 45)
+            hough = im.hough_circle(min_radius=35, max_radius=45)
 
             v, x, y = hough.maxpos()
             vec = hough(x, y)
@@ -367,10 +371,10 @@ class TestArithmetic(PyvipsTester):
         for fmt in all_formats:
             im = test.cast(fmt)
             hough = im.hough_line()
-            
+
             v, x, y = hough.maxpos()
 
-            angle = 360.0 * x // hough.width 
+            angle = 360.0 * x // hough.width
             distance = test.height * y // hough.height
 
             self.assertAlmostEqual(angle, 45)
@@ -383,7 +387,7 @@ class TestArithmetic(PyvipsTester):
             else:
                 return math.sin(math.radians(x))
 
-        self.run_unary(self.all_images, my_sin, fmt = noncomplex_formats)
+        self.run_unary(self.all_images, my_sin, fmt=noncomplex_formats)
 
     def test_cos(self):
         def my_cos(x):
@@ -392,7 +396,7 @@ class TestArithmetic(PyvipsTester):
             else:
                 return math.cos(math.radians(x))
 
-        self.run_unary(self.all_images, my_cos, fmt = noncomplex_formats)
+        self.run_unary(self.all_images, my_cos, fmt=noncomplex_formats)
 
     def test_tan(self):
         def my_tan(x):
@@ -401,7 +405,7 @@ class TestArithmetic(PyvipsTester):
             else:
                 return math.tan(math.radians(x))
 
-        self.run_unary(self.all_images, my_tan, fmt = noncomplex_formats)
+        self.run_unary(self.all_images, my_tan, fmt=noncomplex_formats)
 
     def test_asin(self):
         def my_asin(x):
@@ -411,7 +415,7 @@ class TestArithmetic(PyvipsTester):
                 return math.degrees(math.asin(x))
 
         im = (pyvips.Image.black(100, 100) + [1, 2, 3]) / 3.0
-        self.run_unary([im], my_asin, fmt = noncomplex_formats)
+        self.run_unary([im], my_asin, fmt=noncomplex_formats)
 
     def test_acos(self):
         def my_acos(x):
@@ -421,7 +425,7 @@ class TestArithmetic(PyvipsTester):
                 return math.degrees(math.acos(x))
 
         im = (pyvips.Image.black(100, 100) + [1, 2, 3]) / 3.0
-        self.run_unary([im], my_acos, fmt = noncomplex_formats)
+        self.run_unary([im], my_acos, fmt=noncomplex_formats)
 
     def test_atan(self):
         def my_atan(x):
@@ -431,7 +435,7 @@ class TestArithmetic(PyvipsTester):
                 return math.degrees(math.atan(x))
 
         im = (pyvips.Image.black(100, 100) + [1, 2, 3]) / 3.0
-        self.run_unary([im], my_atan, fmt = noncomplex_formats)
+        self.run_unary([im], my_atan, fmt=noncomplex_formats)
 
     def test_log(self):
         def my_log(x):
@@ -440,7 +444,7 @@ class TestArithmetic(PyvipsTester):
             else:
                 return math.log(x)
 
-        self.run_unary(self.all_images, my_log, fmt = noncomplex_formats)
+        self.run_unary(self.all_images, my_log, fmt=noncomplex_formats)
 
     def test_log10(self):
         def my_log10(x):
@@ -449,7 +453,7 @@ class TestArithmetic(PyvipsTester):
             else:
                 return math.log10(x)
 
-        self.run_unary(self.all_images, my_log10, fmt = noncomplex_formats)
+        self.run_unary(self.all_images, my_log10, fmt=noncomplex_formats)
 
     def test_exp(self):
         def my_exp(x):
@@ -458,7 +462,7 @@ class TestArithmetic(PyvipsTester):
             else:
                 return math.exp(x)
 
-        self.run_unary(self.all_images, my_exp, fmt = noncomplex_formats)
+        self.run_unary(self.all_images, my_exp, fmt=noncomplex_formats)
 
     def test_exp10(self):
         def my_exp10(x):
@@ -467,7 +471,7 @@ class TestArithmetic(PyvipsTester):
             else:
                 return math.pow(10, x)
 
-        self.run_unary(self.all_images, my_exp10, fmt = noncomplex_formats)
+        self.run_unary(self.all_images, my_exp10, fmt=noncomplex_formats)
 
     def test_floor(self):
         def my_floor(x):
@@ -536,7 +540,7 @@ class TestArithmetic(PyvipsTester):
 
     def test_measure(self):
         im = pyvips.Image.black(50, 50)
-        test = im.insert(im + 10, 50, 0, expand = True)
+        test = im.insert(im + 10, 50, 0, expand=True)
 
         for x in noncomplex_formats:
             a = test.cast(x)
@@ -550,7 +554,7 @@ class TestArithmetic(PyvipsTester):
     def test_find_trim(self):
         if pyvips.type_find("VipsOperation", "find_trim") != 0:
             im = pyvips.Image.black(50, 60) + 100
-            test = im.embed(10, 20, 200, 300, extend = "white")
+            test = im.embed(10, 20, 200, 300, extend="white")
 
             for x in unsigned_formats + float_formats:
                 a = test.cast(x)
@@ -579,19 +583,19 @@ class TestArithmetic(PyvipsTester):
 
     def test_project(self):
         im = pyvips.Image.black(50, 50)
-        test = im.insert(im + 10, 50, 0, expand = True)
+        test = im.insert(im + 10, 50, 0, expand=True)
 
         for fmt in noncomplex_formats:
             columns, rows = test.cast(fmt).project()
 
-            self.assertAlmostEqualObjects(columns(10,0), [0])
-            self.assertAlmostEqualObjects(columns(70,0), [50 * 10])
+            self.assertAlmostEqualObjects(columns(10, 0), [0])
+            self.assertAlmostEqualObjects(columns(70, 0), [50 * 10])
 
-            self.assertAlmostEqualObjects(rows(0,10), [50 * 10])
+            self.assertAlmostEqualObjects(rows(0, 10), [50 * 10])
 
     def test_stats(self):
         im = pyvips.Image.black(50, 50)
-        test = im.insert(im + 10, 50, 0, expand = True)
+        test = im.insert(im + 10, 50, 0, expand=True)
 
         for x in noncomplex_formats:
             a = test.cast(x)
@@ -617,6 +621,7 @@ class TestArithmetic(PyvipsTester):
             im2 = [(im + x).cast(fmt) for x in range(0, 100, 10)]
             im3 = pyvips.Image.sum(im2)
             self.assertAlmostEqual(im3.max(), sum(range(0, 100, 10)))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyvips/tests/test_arithmetic.py
+++ b/pyvips/tests/test_arithmetic.py
@@ -548,17 +548,18 @@ class TestArithmetic(PyvipsTester):
             self.assertAlmostEqual(p2, 10)
 
     def test_find_trim(self):
-        im = pyvips.Image.black(50, 60) + 100
-        test = im.embed(10, 20, 200, 300, extend = "white")
+        if pyvips.type_find("VipsOperation", "find_trim") != 0:
+            im = pyvips.Image.black(50, 60) + 100
+            test = im.embed(10, 20, 200, 300, extend = "white")
 
-        for x in unsigned_formats + float_formats:
-            a = test.cast(x)
-            left, top, width, height = a.find_trim()
+            for x in unsigned_formats + float_formats:
+                a = test.cast(x)
+                left, top, width, height = a.find_trim()
 
-            self.assertEqual(left, 10)
-            self.assertEqual(top, 20)
-            self.assertEqual(width, 50)
-            self.assertEqual(height, 60)
+                self.assertEqual(left, 10)
+                self.assertEqual(top, 20)
+                self.assertEqual(width, 50)
+                self.assertEqual(height, 60)
 
     def test_profile(self):
         test = pyvips.Image.black(100, 100).draw_rect(100, 40, 50, 1, 1)

--- a/pyvips/tests/test_colour.py
+++ b/pyvips/tests/test_colour.py
@@ -1,11 +1,15 @@
 # vim: set fileencoding=utf-8 :
+import unittest
 
-from .helpers import *
+import pyvips
+from .helpers import PyvipsTester, JPEG_FILE, SRGB_FILE, \
+    colour_colourspaces, mono_colourspaces
+
 
 class TestColour(PyvipsTester):
     def setUp(self):
-        im = pyvips.Image.mask_ideal(100, 100, 0.5, 
-                                     reject = True, optical = True)
+        im = pyvips.Image.mask_ideal(100, 100, 0.5,
+                                     reject=True, optical=True)
         self.colour = im * [1, 2, 3] + [2, 3, 4]
         self.mono = self.colour.extract_band(1)
         self.all_images = [self.mono, self.colour]
@@ -14,7 +18,7 @@ class TestColour(PyvipsTester):
         # mid-grey in Lab ... put 42 in the extra band, it should be copied
         # unmodified
         test = pyvips.Image.black(100, 100) + [50, 0, 0, 42]
-        test = test.copy(interpretation = pyvips.Interpretation.LAB)
+        test = test.copy(interpretation=pyvips.Interpretation.LAB)
 
         # a long series should come in a circle
         im = test
@@ -23,12 +27,12 @@ class TestColour(PyvipsTester):
             self.assertEqual(im.interpretation, col)
 
             for i in range(0, 4):
-                l = im.extract_band(i).min()
-                h = im.extract_band(i).max()
-                self.assertAlmostEqual(l, h)
+                min_l = im.extract_band(i).min()
+                max_h = im.extract_band(i).max()
+                self.assertAlmostEqual(min_l, max_h)
 
             pixel = im(10, 10)
-            self.assertAlmostEqual(pixel[3], 42, places = 2)
+            self.assertAlmostEqual(pixel[3], 42, places=2)
 
         # alpha won't be equal for RGB16, but it should be preserved if we go
         # there and back
@@ -37,7 +41,7 @@ class TestColour(PyvipsTester):
 
         before = test(10, 10)
         after = im(10, 10)
-        self.assertAlmostEqualObjects(before, after, places = 1)
+        self.assertAlmostEqualObjects(before, after, places=1)
 
         # go between every pair of colour spaces
         for start in colour_colourspaces:
@@ -49,7 +53,7 @@ class TestColour(PyvipsTester):
                 before = test(10, 10)
                 after = im3(10, 10)
 
-                self.assertAlmostEqualObjects(before, after, places = 1)
+                self.assertAlmostEqualObjects(before, after, places=1)
 
         # test Lab->XYZ on mid-grey
         # checked against http://www.brucelindbloom.com
@@ -80,40 +84,40 @@ class TestColour(PyvipsTester):
     def test_dE00(self):
         # put 42 in the extra band, it should be copied unmodified
         reference = pyvips.Image.black(100, 100) + [50, 10, 20, 42]
-        reference = reference.copy(interpretation = pyvips.Interpretation.LAB)
+        reference = reference.copy(interpretation=pyvips.Interpretation.LAB)
         sample = pyvips.Image.black(100, 100) + [40, -20, 10]
-        sample = sample.copy(interpretation = pyvips.Interpretation.LAB)
+        sample = sample.copy(interpretation=pyvips.Interpretation.LAB)
 
         difference = reference.dE00(sample)
         result, alpha = difference(10, 10)
-        self.assertAlmostEqual(result, 30.238, places = 3)
-        self.assertAlmostEqual(alpha, 42.0, places = 3)
+        self.assertAlmostEqual(result, 30.238, places=3)
+        self.assertAlmostEqual(alpha, 42.0, places=3)
 
     def test_dE76(self):
         # put 42 in the extra band, it should be copied unmodified
         reference = pyvips.Image.black(100, 100) + [50, 10, 20, 42]
-        reference = reference.copy(interpretation = pyvips.Interpretation.LAB)
+        reference = reference.copy(interpretation=pyvips.Interpretation.LAB)
         sample = pyvips.Image.black(100, 100) + [40, -20, 10]
-        sample = sample.copy(interpretation = pyvips.Interpretation.LAB)
+        sample = sample.copy(interpretation=pyvips.Interpretation.LAB)
 
         difference = reference.dE76(sample)
         result, alpha = difference(10, 10)
-        self.assertAlmostEqual(result, 33.166, places = 3)
-        self.assertAlmostEqual(alpha, 42.0, places = 3)
+        self.assertAlmostEqual(result, 33.166, places=3)
+        self.assertAlmostEqual(alpha, 42.0, places=3)
 
-    # the vips CMC calculation is based on distance in a colorspace derived from
-    # the CMC formula, so it won't match exactly ... see vips_LCh2CMC() for
-    # details
+    # the vips CMC calculation is based on distance in a colorspace
+    # derived from the CMC formula, so it won't match exactly ...
+    # see vips_LCh2CMC() for details
     def test_dECMC(self):
         reference = pyvips.Image.black(100, 100) + [50, 10, 20, 42]
-        reference = reference.copy(interpretation = pyvips.Interpretation.LAB)
+        reference = reference.copy(interpretation=pyvips.Interpretation.LAB)
         sample = pyvips.Image.black(100, 100) + [55, 11, 23]
-        sample = sample.copy(interpretation = pyvips.Interpretation.LAB)
+        sample = sample.copy(interpretation=pyvips.Interpretation.LAB)
 
         difference = reference.dECMC(sample)
         result, alpha = difference(10, 10)
         self.assertLess(abs(result - 4.97), 0.5)
-        self.assertAlmostEqual(alpha, 42.0, places = 3)
+        self.assertAlmostEqual(alpha, 42.0, places=3)
 
     def test_icc(self):
         test = pyvips.Image.new_from_file(JPEG_FILE)
@@ -122,17 +126,17 @@ class TestColour(PyvipsTester):
         self.assertLess(im.dE76(test).max(), 6)
 
         im = test.icc_import()
-        im2 = im.icc_export(depth = 16)
+        im2 = im.icc_export(depth=16)
         self.assertEqual(im2.format, pyvips.BandFormat.USHORT)
         im3 = im2.icc_import()
         self.assertLess((im - im3).abs().max(), 3)
 
-        im = test.icc_import(intent = pyvips.Intent.ABSOLUTE)
-        im2 = im.icc_export(intent = pyvips.Intent.ABSOLUTE)
+        im = test.icc_import(intent=pyvips.Intent.ABSOLUTE)
+        im2 = im.icc_export(intent=pyvips.Intent.ABSOLUTE)
         self.assertLess(im2.dE76(test).max(), 6)
 
         im = test.icc_import()
-        im2 = im.icc_export(output_profile = SRGB_FILE)
+        im2 = im.icc_export(output_profile=SRGB_FILE)
         im3 = im.colourspace(pyvips.Interpretation.SRGB)
         self.assertLess(im2.dE76(im3).max(), 6)
 
@@ -144,14 +148,15 @@ class TestColour(PyvipsTester):
         self.assertLess(im.dE76(im3).max(), 6)
         self.assertNotEqual(len(before_profile), len(after_profile))
 
-        im = test.icc_import(input_profile = SRGB_FILE)
+        im = test.icc_import(input_profile=SRGB_FILE)
         im2 = test.icc_import()
         self.assertLess(6, im.dE76(im2).max())
 
-        im = test.icc_import(pcs = pyvips.PCS.XYZ)
+        im = test.icc_import(pcs=pyvips.PCS.XYZ)
         self.assertEqual(im.interpretation, pyvips.Interpretation.XYZ)
         im = test.icc_import()
         self.assertEqual(im.interpretation, pyvips.Interpretation.LAB)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyvips/tests/test_convolution.py
+++ b/pyvips/tests/test_convolution.py
@@ -1,8 +1,11 @@
 # vim: set fileencoding=utf-8 :
-
 import operator
+import unittest
 from functools import reduce
-from .helpers import *
+
+import pyvips
+from .helpers import PyvipsTester, noncomplex_formats, run_fn2, run_fn
+
 
 # point convolution
 def conv(image, mask, x_position, y_position):
@@ -16,6 +19,7 @@ def conv(image, mask, x_position, y_position):
 
     return run_fn2(operator.truediv, s, mask.get_scale())
 
+
 def compass(image, mask, x_position, y_position, n_rot, fn):
     acc = []
     for i in range(0, n_rot):
@@ -26,34 +30,35 @@ def compass(image, mask, x_position, y_position, n_rot, fn):
 
     return reduce(lambda a, b: run_fn2(fn, a, b), acc)
 
-class TestConvolution(PyvipsTester):
 
+class TestConvolution(PyvipsTester):
     def setUp(self):
-        im = pyvips.Image.mask_ideal(100, 100, 0.5, reject = True, optical = True)
+        im = pyvips.Image.mask_ideal(100, 100, 0.5, reject=True, optical=True)
         self.colour = im * [1, 2, 3] + [2, 3, 4]
-        self.colour = self.colour.copy(interpretation = pyvips.Interpretation.SRGB)
+        self.colour = self.colour.copy(
+            interpretation=pyvips.Interpretation.SRGB)
         self.mono = self.colour.extract_band(1)
-        self.mono = self.mono.copy(interpretation = pyvips.Interpretation.B_W)
+        self.mono = self.mono.copy(interpretation=pyvips.Interpretation.B_W)
         self.all_images = [self.mono, self.colour]
-        self.sharp = pyvips.Image.new_from_array([[-1, -1,  -1],
-                                                [-1,  16, -1],
-                                                [-1, -1,  -1]], scale = 8)
+        self.sharp = pyvips.Image.new_from_array([[-1, -1, -1],
+                                                  [-1, 16, -1],
+                                                  [-1, -1, -1]], scale=8)
         self.blur = pyvips.Image.new_from_array([[1, 1, 1],
-                                               [1, 1, 1],
-                                               [1, 1, 1]], scale = 9)
-        self.line = pyvips.Image.new_from_array([[ 1,  1,  1],
-                                               [-2, -2, -2],
-                                               [ 1,  1,  1]])
-        self.sobel = pyvips.Image.new_from_array([[ 1,  2,  1],
-                                                [ 0,  0,  0],
-                                                [-1, -2, -1]])
+                                                 [1, 1, 1],
+                                                 [1, 1, 1]], scale=9)
+        self.line = pyvips.Image.new_from_array([[1, 1, 1],
+                                                 [-2, -2, -2],
+                                                 [1, 1, 1]])
+        self.sobel = pyvips.Image.new_from_array([[1, 2, 1],
+                                                  [0, 0, 0],
+                                                  [-1, -2, -1]])
         self.all_masks = [self.sharp, self.blur, self.line, self.sobel]
 
     def test_conv(self):
         for im in self.all_images:
             for msk in self.all_masks:
                 for prec in [pyvips.Precision.INTEGER, pyvips.Precision.FLOAT]:
-                    convolved = im.conv(msk, precision = prec)
+                    convolved = im.conv(msk, precision=prec)
 
                     result = convolved(25, 50)
                     true = conv(im, msk, 24, 49)
@@ -71,7 +76,8 @@ class TestConvolution(PyvipsTester):
                 msk.matrixprint()
                 print("im.bands = %s" % im.bands)
 
-                convolved = im.conv(msk, precision = pyvips.Precision.APPROXIMATE)
+                convolved = im.conv(msk,
+                                    precision=pyvips.Precision.APPROXIMATE)
 
                 result = convolved(25, 50)
                 true = conv(im, msk, 24, 49)
@@ -89,10 +95,10 @@ class TestConvolution(PyvipsTester):
                 for prec in [pyvips.Precision.INTEGER, pyvips.Precision.FLOAT]:
                     for times in range(1, 4):
                         convolved = im.compass(msk,
-                                               times = times,
-                                               angle = pyvips.Angle45.D45,
-                                               combine = pyvips.Combine.MAX,
-                                               precision = prec)
+                                               times=times,
+                                               angle=pyvips.Angle45.D45,
+                                               combine=pyvips.Combine.MAX,
+                                               precision=prec)
 
                         result = convolved(25, 50)
                         true = compass(im, msk, 24, 49, times, max)
@@ -103,10 +109,10 @@ class TestConvolution(PyvipsTester):
                 for prec in [pyvips.Precision.INTEGER, pyvips.Precision.FLOAT]:
                     for times in range(1, 4):
                         convolved = im.compass(msk,
-                                               times = times,
-                                               angle = pyvips.Angle45.D45,
-                                               combine = pyvips.Combine.SUM,
-                                               precision = prec)
+                                               times=times,
+                                               angle=pyvips.Angle45.D45,
+                                               combine=pyvips.Combine.SUM,
+                                               precision=prec)
 
                         result = convolved(25, 50)
                         true = compass(im, msk, 24, 49, times, operator.add)
@@ -116,22 +122,22 @@ class TestConvolution(PyvipsTester):
         for im in self.all_images:
             for prec in [pyvips.Precision.INTEGER, pyvips.Precision.FLOAT]:
                 gmask = pyvips.Image.gaussmat(2, 0.1,
-                                            precision = prec)
+                                              precision=prec)
                 gmask_sep = pyvips.Image.gaussmat(2, 0.1,
-                                                separable = True,
-                                                precision = prec)
+                                                  separable=True,
+                                                  precision=prec)
 
                 self.assertEqual(gmask.width, gmask.height)
                 self.assertEqual(gmask_sep.width, gmask.width)
                 self.assertEqual(gmask_sep.height, 1)
 
-                a = im.conv(gmask, precision = prec)
-                b = im.convsep(gmask_sep, precision = prec)
+                a = im.conv(gmask, precision=prec)
+                b = im.convsep(gmask_sep, precision=prec)
 
                 a_point = a(25, 50)
                 b_point = b(25, 50)
 
-                self.assertAlmostEqualObjects(a_point, b_point, places = 1)
+                self.assertAlmostEqualObjects(a_point, b_point, places=1)
 
     def test_fastcor(self):
         for im in self.all_images:
@@ -161,38 +167,38 @@ class TestConvolution(PyvipsTester):
                 for i in range(5, 10):
                     sigma = i / 5.0
                     gmask = pyvips.Image.gaussmat(sigma, 0.2,
-                                                precision = prec)
+                                                  precision=prec)
 
-                    a = im.conv(gmask, precision = prec)
-                    b = im.gaussblur(sigma, min_ampl = 0.2, precision = prec)
+                    a = im.conv(gmask, precision=prec)
+                    b = im.gaussblur(sigma, min_ampl=0.2, precision=prec)
 
                     a_point = a(25, 50)
                     b_point = b(25, 50)
 
-                    self.assertAlmostEqualObjects(a_point, b_point, places = 1)
+                    self.assertAlmostEqualObjects(a_point, b_point, places=1)
 
     def test_sharpen(self):
         for im in self.all_images:
             for fmt in noncomplex_formats:
                 # old vipses used "radius", check that that still works
-                sharp = im.sharpen(radius = 5)
+                sharp = im.sharpen(radius=5)
 
                 for sigma in [0.5, 1, 1.5, 2]:
                     im = im.cast(fmt)
-                    sharp = im.sharpen(sigma = sigma)
+                    sharp = im.sharpen(sigma=sigma)
 
                     # hard to test much more than this
                     self.assertEqual(im.width, sharp.width)
                     self.assertEqual(im.height, sharp.height)
 
                     # if m1 and m2 are zero, sharpen should do nothing
-                    sharp = im.sharpen(sigma = sigma, m1 = 0, m2 = 0)
+                    sharp = im.sharpen(sigma=sigma, m1=0, m2=0)
                     sharp = sharp.colourspace(im.interpretation)
-                    #print("testing sig = %g" % sigma)
-                    #print("testing fmt = %s" % fmt)
-                    #print("max diff = %g" % (im - sharp).abs().max())
+                    # print("testing sig = %g" % sigma)
+                    # print("testing fmt = %s" % fmt)
+                    # print("max diff = %g" % (im - sharp).abs().max())
                     self.assertEqual((im - sharp).abs().max(), 0)
+
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/pyvips/tests/test_create.py
+++ b/pyvips/tests/test_create.py
@@ -375,13 +375,14 @@ class TestCreate(PyvipsTester):
         self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
 
     def test_text(self):
-        im = pyvips.Image.text("Hello, world!")
-        self.assertTrue(im.width > 10)
-        self.assertTrue(im.height > 10)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.UCHAR)
-        self.assertEqual(im.max(), 255)
-        self.assertEqual(im.min(), 0)
+        if pyvips.type_find("VipsOperation", "text") != 0:
+            im = pyvips.Image.text("Hello, world!")
+            self.assertTrue(im.width > 10)
+            self.assertTrue(im.height > 10)
+            self.assertEqual(im.bands, 1)
+            self.assertEqual(im.format, pyvips.BandFormat.UCHAR)
+            self.assertEqual(im.max(), 255)
+            self.assertEqual(im.min(), 0)
 
     def test_tonelut(self):
         im = pyvips.Image.tonelut()

--- a/pyvips/tests/test_create.py
+++ b/pyvips/tests/test_create.py
@@ -1,6 +1,9 @@
 # vim: set fileencoding=utf-8 :
+import unittest
 
-from .helpers import *
+import pyvips
+from .helpers import PyvipsTester
+
 
 class TestCreate(PyvipsTester):
     def test_black(self):
@@ -10,25 +13,25 @@ class TestCreate(PyvipsTester):
         self.assertEqual(im.height, 100)
         self.assertEqual(im.format, pyvips.BandFormat.UCHAR)
         self.assertEqual(im.bands, 1)
-        for i in range (0, 100):
+        for i in range(0, 100):
             pixel = im(i, i)
             self.assertEqual(len(pixel), 1)
             self.assertEqual(pixel[0], 0)
 
-        im = pyvips.Image.black(100, 100, bands = 3)
+        im = pyvips.Image.black(100, 100, bands=3)
 
         self.assertEqual(im.width, 100)
         self.assertEqual(im.height, 100)
         self.assertEqual(im.format, pyvips.BandFormat.UCHAR)
         self.assertEqual(im.bands, 3)
-        for i in range (0, 100):
+        for i in range(0, 100):
             pixel = im(i, i)
             self.assertEqual(len(pixel), 3)
             self.assertAlmostEqualObjects(pixel, [0, 0, 0])
 
     def test_buildlut(self):
-        M = pyvips.Image.new_from_array([[0, 0], 
-                                       [255, 100]])
+        M = pyvips.Image.new_from_array([[0, 0],
+                                         [255, 100]])
         lut = M.buildlut()
         self.assertEqual(lut.width, 256)
         self.assertEqual(lut.height, 1)
@@ -40,9 +43,9 @@ class TestCreate(PyvipsTester):
         p = lut(10, 0)
         self.assertEqual(p[0], 100 * 10.0 / 255.0)
 
-        M = pyvips.Image.new_from_array([[0, 0, 100], 
-                                       [255, 100, 0],
-                                       [128, 10, 90]])
+        M = pyvips.Image.new_from_array([[0, 0, 100],
+                                         [255, 100, 0],
+                                         [128, 10, 90]])
         lut = M.buildlut()
         self.assertEqual(lut.width, 256)
         self.assertEqual(lut.height, 1)
@@ -61,7 +64,7 @@ class TestCreate(PyvipsTester):
         self.assertEqual(im.max(), 1.0)
         self.assertEqual(im.min(), -1.0)
 
-        im = pyvips.Image.eye(100, 90, uchar = True)
+        im = pyvips.Image.eye(100, 90, uchar=True)
         self.assertEqual(im.width, 100)
         self.assertEqual(im.height, 90)
         self.assertEqual(im.bands, 1)
@@ -89,8 +92,8 @@ class TestCreate(PyvipsTester):
         p = im(im.width / 2, im.height / 2)
         self.assertEqual(p[0], 20.0)
 
-        im = pyvips.Image.gaussmat(1, 0.1, 
-                                 separable = True, precision = "float")
+        im = pyvips.Image.gaussmat(1, 0.1,
+                                   separable=True, precision="float")
         self.assertEqual(im.width, 5)
         self.assertEqual(im.height, 1)
         self.assertEqual(im.bands, 1)
@@ -109,7 +112,7 @@ class TestCreate(PyvipsTester):
         self.assertEqual(im.bands, 1)
         self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
 
-        im = pyvips.Image.gaussnoise(100, 90, sigma = 10, mean = 100)
+        im = pyvips.Image.gaussnoise(100, 90, sigma=10, mean=100)
         self.assertEqual(im.width, 100)
         self.assertEqual(im.height, 90)
         self.assertEqual(im.bands, 1)
@@ -118,8 +121,8 @@ class TestCreate(PyvipsTester):
         sigma = im.deviate()
         mean = im.avg()
 
-        self.assertAlmostEqual(sigma, 10, places = 0)
-        self.assertAlmostEqual(mean, 100, places = 0)
+        self.assertAlmostEqual(sigma, 10, places=0)
+        self.assertAlmostEqual(mean, 100, places=0)
 
     def test_grey(self):
         im = pyvips.Image.grey(100, 90)
@@ -137,7 +140,7 @@ class TestCreate(PyvipsTester):
         p = im(99, 89)
         self.assertEqual(p[0], 1.0)
 
-        im = pyvips.Image.grey(100, 90, uchar = True)
+        im = pyvips.Image.grey(100, 90, uchar=True)
         self.assertEqual(im.width, 100)
         self.assertEqual(im.height, 90)
         self.assertEqual(im.bands, 1)
@@ -166,7 +169,7 @@ class TestCreate(PyvipsTester):
         p = im(128, 0)
         self.assertEqual(p[0], 128.0)
 
-        im = pyvips.Image.identity(ushort = True)
+        im = pyvips.Image.identity(ushort=True)
         self.assertEqual(im.width, 65536)
         self.assertEqual(im.height, 1)
         self.assertEqual(im.bands, 1)
@@ -180,9 +183,9 @@ class TestCreate(PyvipsTester):
         self.assertEqual(p[0], 65535)
 
     def test_invertlut(self):
-        lut = pyvips.Image.new_from_array([[0.1, 0.2, 0.3, 0.1], 
-                                         [0.2, 0.4, 0.4, 0.2], 
-                                         [0.7, 0.5, 0.6, 0.3]])
+        lut = pyvips.Image.new_from_array([[0.1, 0.2, 0.3, 0.1],
+                                           [0.2, 0.4, 0.4, 0.2],
+                                           [0.7, 0.5, 0.6, 0.3]])
         im = lut.invertlut()
         self.assertEqual(im.width, 256)
         self.assertEqual(im.height, 1)
@@ -194,11 +197,11 @@ class TestCreate(PyvipsTester):
         p = im(255, 0)
         self.assertAlmostEqualObjects(p, [1, 1, 1])
         p = im(0.2 * 255, 0)
-        self.assertAlmostEqual(p[0], 0.1, places = 2)
+        self.assertAlmostEqual(p[0], 0.1, places=2)
         p = im(0.3 * 255, 0)
-        self.assertAlmostEqual(p[1], 0.1, places = 2)
+        self.assertAlmostEqual(p[1], 0.1, places=2)
         p = im(0.1 * 255, 0)
-        self.assertAlmostEqual(p[2], 0.1, places = 2)
+        self.assertAlmostEqual(p[2], 0.1, places=2)
 
     def test_logmat(self):
         im = pyvips.Image.logmat(1, 0.1)
@@ -213,8 +216,8 @@ class TestCreate(PyvipsTester):
         p = im(im.width / 2, im.height / 2)
         self.assertEqual(p[0], 20.0)
 
-        im = pyvips.Image.logmat(1, 0.1, 
-                               separable = True, precision = "float")
+        im = pyvips.Image.logmat(1, 0.1,
+                                 separable=True, precision="float")
         self.assertEqual(im.width, 7)
         self.assertEqual(im.height, 1)
         self.assertEqual(im.bands, 1)
@@ -227,17 +230,20 @@ class TestCreate(PyvipsTester):
         self.assertEqual(p[0], 1.0)
 
     def test_mask_butterworth_band(self):
-        im = pyvips.Image.mask_butterworth_band(128, 128, 2, 0.5, 0.5, 0.7, 0.1)
+        im = pyvips.Image.mask_butterworth_band(128, 128, 2,
+                                                0.5, 0.5, 0.7,
+                                                0.1)
         self.assertEqual(im.width, 128)
         self.assertEqual(im.height, 128)
         self.assertEqual(im.bands, 1)
         self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
-        self.assertAlmostEqual(im.max(), 1, places = 2)
+        self.assertAlmostEqual(im.max(), 1, places=2)
         p = im(32, 32)
         self.assertEqual(p[0], 1.0)
 
-        im = pyvips.Image.mask_butterworth_band(128, 128, 2, 0.5, 0.5, 0.7, 0.1,
-                                             uchar = True, optical = True)
+        im = pyvips.Image.mask_butterworth_band(128, 128, 2,
+                                                0.5, 0.5, 0.7,
+                                                0.1, uchar=True, optical=True)
         self.assertEqual(im.width, 128)
         self.assertEqual(im.height, 128)
         self.assertEqual(im.bands, 1)
@@ -248,9 +254,10 @@ class TestCreate(PyvipsTester):
         p = im(64, 64)
         self.assertEqual(p[0], 255.0)
 
-        im = pyvips.Image.mask_butterworth_band(128, 128, 2, 0.5, 0.5, 0.7, 0.1,
-                                             uchar = True, optical = True, 
-                                             nodc = True)
+        im = pyvips.Image.mask_butterworth_band(128, 128, 2,
+                                                0.5, 0.5, 0.7,
+                                                0.1, uchar=True, optical=True,
+                                                nodc=True)
         self.assertEqual(im.width, 128)
         self.assertEqual(im.height, 128)
         self.assertEqual(im.bands, 1)
@@ -262,38 +269,38 @@ class TestCreate(PyvipsTester):
         self.assertNotEqual(p[0], 255)
 
     def test_mask_butterworth(self):
-        im = pyvips.Image.mask_butterworth(128, 128, 2, 0.7, 0.1, 
-                                         nodc = True)
+        im = pyvips.Image.mask_butterworth(128, 128, 2, 0.7, 0.1,
+                                           nodc=True)
         self.assertEqual(im.width, 128)
         self.assertEqual(im.height, 128)
         self.assertEqual(im.bands, 1)
         self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
-        self.assertAlmostEqual(im.min(), 0, places = 2)
+        self.assertAlmostEqual(im.min(), 0, places=2)
         p = im(0, 0)
         self.assertEqual(p[0], 0.0)
         v, x, y = im.maxpos()
         self.assertEqual(x, 64)
         self.assertEqual(y, 64)
 
-        im = pyvips.Image.mask_butterworth(128, 128, 2, 0.7, 0.1, 
-                                         optical = True, uchar = True)
+        im = pyvips.Image.mask_butterworth(128, 128, 2, 0.7, 0.1,
+                                           optical=True, uchar=True)
         self.assertEqual(im.width, 128)
         self.assertEqual(im.height, 128)
         self.assertEqual(im.bands, 1)
         self.assertEqual(im.format, pyvips.BandFormat.UCHAR)
-        self.assertAlmostEqual(im.min(), 0, places = 2)
+        self.assertAlmostEqual(im.min(), 0, places=2)
         p = im(64, 64)
         self.assertEqual(p[0], 255)
 
     def test_mask_butterworth_ring(self):
         im = pyvips.Image.mask_butterworth_ring(128, 128, 2, 0.7, 0.1, 0.5,
-                                         nodc = True)
+                                                nodc=True)
         self.assertEqual(im.width, 128)
         self.assertEqual(im.height, 128)
         self.assertEqual(im.bands, 1)
         self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
         p = im(45, 0)
-        self.assertAlmostEqual(p[0], 1.0, places = 4)
+        self.assertAlmostEqual(p[0], 1.0, places=4)
         v, x, y = im.minpos()
         self.assertEqual(x, 64)
         self.assertEqual(y, 64)
@@ -311,30 +318,30 @@ class TestCreate(PyvipsTester):
         self.assertEqual(im.height, 128)
         self.assertEqual(im.bands, 1)
         self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
-        self.assertAlmostEqual(im.max(), 1, places = 2)
+        self.assertAlmostEqual(im.max(), 1, places=2)
         p = im(32, 32)
         self.assertEqual(p[0], 1.0)
 
     def test_mask_gaussian(self):
-        im = pyvips.Image.mask_gaussian(128, 128, 0.7, 0.1, 
-                                         nodc = True)
+        im = pyvips.Image.mask_gaussian(128, 128, 0.7, 0.1,
+                                        nodc=True)
         self.assertEqual(im.width, 128)
         self.assertEqual(im.height, 128)
         self.assertEqual(im.bands, 1)
         self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
-        self.assertAlmostEqual(im.min(), 0, places = 2)
+        self.assertAlmostEqual(im.min(), 0, places=2)
         p = im(0, 0)
         self.assertEqual(p[0], 0.0)
 
     def test_mask_gaussian_ring(self):
         im = pyvips.Image.mask_gaussian_ring(128, 128, 0.7, 0.1, 0.5,
-                                         nodc = True)
+                                             nodc=True)
         self.assertEqual(im.width, 128)
         self.assertEqual(im.height, 128)
         self.assertEqual(im.bands, 1)
         self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
         p = im(45, 0)
-        self.assertAlmostEqual(p[0], 1.0, places = 3)
+        self.assertAlmostEqual(p[0], 1.0, places=3)
 
     def test_mask_ideal_band(self):
         im = pyvips.Image.mask_ideal_band(128, 128, 0.5, 0.5, 0.7)
@@ -342,30 +349,30 @@ class TestCreate(PyvipsTester):
         self.assertEqual(im.height, 128)
         self.assertEqual(im.bands, 1)
         self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
-        self.assertAlmostEqual(im.max(), 1, places = 2)
+        self.assertAlmostEqual(im.max(), 1, places=2)
         p = im(32, 32)
         self.assertEqual(p[0], 1.0)
 
     def test_mask_ideal(self):
-        im = pyvips.Image.mask_ideal(128, 128, 0.7, 
-                                         nodc = True)
+        im = pyvips.Image.mask_ideal(128, 128, 0.7,
+                                     nodc=True)
         self.assertEqual(im.width, 128)
         self.assertEqual(im.height, 128)
         self.assertEqual(im.bands, 1)
         self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
-        self.assertAlmostEqual(im.min(), 0, places = 2)
+        self.assertAlmostEqual(im.min(), 0, places=2)
         p = im(0, 0)
         self.assertEqual(p[0], 0.0)
 
-    def test_mask_gaussian_ring(self):
+    def test_mask_gaussian_ring_2(self):
         im = pyvips.Image.mask_ideal_ring(128, 128, 0.7, 0.5,
-                                         nodc = True)
+                                          nodc=True)
         self.assertEqual(im.width, 128)
         self.assertEqual(im.height, 128)
         self.assertEqual(im.bands, 1)
         self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
         p = im(45, 0)
-        self.assertAlmostEqual(p[0], 1.0, places = 3)
+        self.assertAlmostEqual(p[0], 1.0, places=3)
 
     def test_sines(self):
         im = pyvips.Image.sines(128, 128)
@@ -422,6 +429,6 @@ class TestCreate(PyvipsTester):
         self.assertEqual(im.bands, 1)
         self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
 
+
 if __name__ == '__main__':
     unittest.main()
-

--- a/pyvips/tests/test_draw.py
+++ b/pyvips/tests/test_draw.py
@@ -1,9 +1,11 @@
 # vim: set fileencoding=utf-8 :
+import unittest
 
-from .helpers import *
+import pyvips
+from .helpers import PyvipsTester
+
 
 class TestDraw(PyvipsTester):
-
     def test_draw_circle(self):
         im = pyvips.Image.black(100, 100)
         im = im.draw_circle(100, 50, 50, 25)
@@ -15,7 +17,7 @@ class TestDraw(PyvipsTester):
         self.assertEqual(pixel[0], 0)
 
         im = pyvips.Image.black(100, 100)
-        im = im.draw_circle(100, 50, 50, 25, fill = True)
+        im = im.draw_circle(100, 50, 50, 25, fill=True)
         pixel = im(25, 50)
         self.assertEqual(len(pixel), 1)
         self.assertEqual(pixel[0], 100)
@@ -30,20 +32,20 @@ class TestDraw(PyvipsTester):
         im = im.draw_flood(100, 50, 50)
 
         im2 = pyvips.Image.black(100, 100)
-        im2 = im.draw_circle(100, 50, 50, 25, fill = True)
+        im2 = im.draw_circle(100, 50, 50, 25, fill=True)
 
         diff = (im - im2).abs().max()
         self.assertEqual(diff, 0)
 
     def test_draw_image(self):
         im = pyvips.Image.black(51, 51)
-        im = im.draw_circle(100, 25, 25, 25, fill = True)
+        im = im.draw_circle(100, 25, 25, 25, fill=True)
 
         im2 = pyvips.Image.black(100, 100)
         im2 = im2.draw_image(im, 25, 25)
 
         im3 = pyvips.Image.black(100, 100)
-        im3 = im3.draw_circle(100, 50, 50, 25, fill = True)
+        im3 = im3.draw_circle(100, 50, 50, 25, fill=True)
 
         diff = (im2 - im3).abs().max()
         self.assertEqual(diff, 0)
@@ -60,20 +62,20 @@ class TestDraw(PyvipsTester):
 
     def test_draw_mask(self):
         mask = pyvips.Image.black(51, 51)
-        mask = mask.draw_circle(128, 25, 25, 25, fill = True)
+        mask = mask.draw_circle(128, 25, 25, 25, fill=True)
 
         im = pyvips.Image.black(100, 100)
         im = im.draw_mask(200, mask, 25, 25)
 
         im2 = pyvips.Image.black(100, 100)
-        im2 = im2.draw_circle(100, 50, 50, 25, fill = True)
+        im2 = im2.draw_circle(100, 50, 50, 25, fill=True)
 
         diff = (im - im2).abs().max()
         self.assertEqual(diff, 0)
 
     def test_draw_rect(self):
         im = pyvips.Image.black(100, 100)
-        im = im.draw_rect(100, 25, 25, 50, 50, fill = True)
+        im = im.draw_rect(100, 25, 25, 50, 50, fill=True)
 
         im2 = pyvips.Image.black(100, 100)
         for y in range(25, 75):
@@ -84,16 +86,17 @@ class TestDraw(PyvipsTester):
 
     def test_draw_smudge(self):
         im = pyvips.Image.black(100, 100)
-        im = im.draw_circle(100, 50, 50, 25, fill = True)
+        im = im.draw_circle(100, 50, 50, 25, fill=True)
 
         im2 = im.draw_smudge(10, 10, 50, 50)
 
         im3 = im.crop(10, 10, 50, 50)
-        
+
         im4 = im2.draw_image(im3, 10, 10)
 
         diff = (im4 - im).abs().max()
         self.assertEqual(diff, 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyvips/tests/test_foreign.py
+++ b/pyvips/tests/test_foreign.py
@@ -1,10 +1,18 @@
 # vim: set fileencoding=utf-8 :
-
 import shutil
-from .helpers import *
+import unittest
+
+import os
+
+import pyvips
+from .helpers import PyvipsTester, JPEG_FILE, SRGB_FILE,\
+    MATLAB_FILE, PNG_FILE, TIF_FILE, OME_FILE, ANALYZE_FILE, \
+    GIF_FILE, WEBP_FILE, EXR_FILE, FITS_FILE, OPENSLIDE_FILE, \
+    PDF_FILE, SVG_FILE, SVGZ_FILE, SVG_GZ_FILE, GIF_ANIM_FILE, \
+    DICOM_FILE, temp_filename
+
 
 class TestForeign(PyvipsTester):
-
     def setUp(self):
         self.colour = pyvips.Image.jpegload(JPEG_FILE)
         self.mono = self.colour.extract_band(1)
@@ -13,7 +21,7 @@ class TestForeign(PyvipsTester):
         self.rad = self.colour.float2rad()
         self.rad.remove("icc-profile-data")
         self.cmyk = self.colour.bandjoin(self.mono)
-        self.cmyk = self.cmyk.copy(interpretation = pyvips.Interpretation.CMYK)
+        self.cmyk = self.cmyk.copy(interpretation=pyvips.Interpretation.CMYK)
         self.cmyk.remove("icc-profile-data")
 
         im = pyvips.Image.new_from_file(GIF_FILE)
@@ -46,7 +54,7 @@ class TestForeign(PyvipsTester):
         self.assertEqual(max_diff, 0)
 
     def save_load_file(self, format, options, im, thresh):
-        # yuk! 
+        # yuk!
         # but we can't set format parameters for pyvips.Image.new_temp_file()
         filename = temp_filename(format)
 
@@ -62,7 +70,7 @@ class TestForeign(PyvipsTester):
 
         os.unlink(filename)
 
-    def save_load_buffer(self, saver, loader, im, max_diff = 0):
+    def save_load_buffer(self, saver, loader, im, max_diff=0):
         buf = pyvips.Operation.call(saver, im)
         x = pyvips.Operation.call(loader, buf)
 
@@ -71,7 +79,7 @@ class TestForeign(PyvipsTester):
         self.assertEqual(im.bands, x.bands)
         self.assertLessEqual((im - x).abs().max(), max_diff)
 
-    def save_buffer_tempfile(self, saver, suf, im, max_diff = 0):
+    def save_buffer_tempfile(self, saver, suf, im, max_diff=0):
         filename = temp_filename(suf)
 
         buf = pyvips.Operation.call(saver, im)
@@ -124,7 +132,7 @@ class TestForeign(PyvipsTester):
         self.save_load("%s.jpg", self.colour)
 
         self.buffer_loader("jpegload_buffer", JPEG_FILE, jpeg_valid)
-        self.save_load_buffer("jpegsave_buffer", "jpegload_buffer", 
+        self.save_load_buffer("jpegsave_buffer", "jpegload_buffer",
                               self.colour, 80)
 
         # see if we have exif parsing: our test image has this field
@@ -169,14 +177,14 @@ class TestForeign(PyvipsTester):
             x.set_value("orientation", 6)
             x.write_to_file(filename)
             x1 = pyvips.Image.new_from_file(filename)
-            x2 = pyvips.Image.new_from_file(filename, autorotate = True)
+            x2 = pyvips.Image.new_from_file(filename, autorotate=True)
             self.assertEqual(x1.width, x2.height)
             self.assertEqual(x1.height, x2.width)
             os.unlink(filename)
 
     def test_png(self):
         if pyvips.type_find("VipsForeign", "pngload") == 0 or \
-            not os.path.isfile(PNG_FILE):
+                not os.path.isfile(PNG_FILE):
             print("no png support, skipping test")
 
         def png_valid(self, im):
@@ -194,7 +202,7 @@ class TestForeign(PyvipsTester):
 
     def test_tiff(self):
         if pyvips.type_find("VipsForeign", "tiffload") == 0 or \
-            not os.path.isfile(TIF_FILE):
+                not os.path.isfile(TIF_FILE):
             print("no tiff support, skipping test")
             return
 
@@ -207,7 +215,9 @@ class TestForeign(PyvipsTester):
 
         self.file_loader("tiffload", TIF_FILE, tiff_valid)
         self.buffer_loader("tiffload_buffer", TIF_FILE, tiff_valid)
-        self.save_load_buffer("tiffsave_buffer", "tiffload_buffer", self.colour)
+        self.save_load_buffer("tiffsave_buffer",
+                              "tiffload_buffer",
+                              self.colour)
         self.save_load("%s.tif", self.mono)
         self.save_load("%s.tif", self.colour)
         self.save_load("%s.tif", self.cmyk)
@@ -222,11 +232,11 @@ class TestForeign(PyvipsTester):
                             self.colour, 0)
         self.save_load_file(".tif", "[tile]", self.colour, 0)
         self.save_load_file(".tif", "[tile,pyramid]", self.colour, 0)
-        self.save_load_file(".tif", 
+        self.save_load_file(".tif",
                             "[tile,pyramid,compression=jpeg]", self.colour, 80)
         self.save_load_file(".tif", "[bigtiff]", self.colour, 0)
         self.save_load_file(".tif", "[compression=jpeg]", self.colour, 80)
-        self.save_load_file(".tif", 
+        self.save_load_file(".tif",
                             "[tile,tile-width=256]", self.colour, 10)
 
         # we need a copy of the image to set the new metadata on
@@ -269,7 +279,7 @@ class TestForeign(PyvipsTester):
         x.write_to_file(filename)
 
         x1 = pyvips.Image.new_from_file(filename)
-        x2 = pyvips.Image.new_from_file(filename, autorotate = True)
+        x2 = pyvips.Image.new_from_file(filename, autorotate=True)
         self.assertEqual(x1.width, x2.height)
         self.assertEqual(x1.height, x2.width)
         os.unlink(filename)
@@ -279,44 +289,44 @@ class TestForeign(PyvipsTester):
         self.assertEqual(x.height, 167)
         page_height = x.height
 
-        x = pyvips.Image.new_from_file(OME_FILE, n = -1)
+        x = pyvips.Image.new_from_file(OME_FILE, n=-1)
         self.assertEqual(x.width, 439)
         self.assertEqual(x.height, page_height * 15)
 
-        x = pyvips.Image.new_from_file(OME_FILE, page = 1, n = -1)
+        x = pyvips.Image.new_from_file(OME_FILE, page=1, n=-1)
         self.assertEqual(x.width, 439)
         self.assertEqual(x.height, page_height * 14)
 
-        x = pyvips.Image.new_from_file(OME_FILE, page = 1, n = 2)
+        x = pyvips.Image.new_from_file(OME_FILE, page=1, n=2)
         self.assertEqual(x.width, 439)
         self.assertEqual(x.height, page_height * 2)
 
-        x = pyvips.Image.new_from_file(OME_FILE, n = -1)
-        self.assertEqual(x(0,166)[0], 96)
-        self.assertEqual(x(0,167)[0], 0)
-        self.assertEqual(x(0,168)[0], 1)
+        x = pyvips.Image.new_from_file(OME_FILE, n=-1)
+        self.assertEqual(x(0, 166)[0], 96)
+        self.assertEqual(x(0, 167)[0], 0)
+        self.assertEqual(x(0, 168)[0], 1)
 
         filename = temp_filename('.tif')
         x.write_to_file(filename)
 
-        x = pyvips.Image.new_from_file(filename, n = -1)
+        x = pyvips.Image.new_from_file(filename, n=-1)
         self.assertEqual(x.width, 439)
         self.assertEqual(x.height, page_height * 15)
-        self.assertEqual(x(0,166)[0], 96)
-        self.assertEqual(x(0,167)[0], 0)
-        self.assertEqual(x(0,168)[0], 1)
+        self.assertEqual(x(0, 166)[0], 96)
+        self.assertEqual(x(0, 167)[0], 0)
+        self.assertEqual(x(0, 168)[0], 1)
 
         os.unlink(filename)
 
     def test_magickload(self):
         if pyvips.type_find("VipsForeign", "magickload") == 0 or \
-            not os.path.isfile(GIF_FILE):
+                not os.path.isfile(GIF_FILE):
             print("no magick support, skipping test")
             return
 
         def gif_valid(self, im):
             # some libMagick produce an RGB for this image, some a mono, some
-            # rgba, some have a valid alpha, some don't :-( 
+            # rgba, some have a valid alpha, some don't :-(
             # therefore ... just test channel 0
             a = im(10, 10)[0]
 
@@ -332,21 +342,21 @@ class TestForeign(PyvipsTester):
         self.assertEqual(im.bands, 4)
 
         # density should change size of generated svg
-        im = pyvips.Image.magickload(SVG_FILE, density = '100')
+        im = pyvips.Image.magickload(SVG_FILE, density='100')
         width = im.width
         height = im.height
-        im = pyvips.Image.magickload(SVG_FILE, density = '200')
+        im = pyvips.Image.magickload(SVG_FILE, density='200')
         # This seems to fail on travis, no idea why, some problem in their IM
         # perhaps
-        #self.assertEqual(im.width, width * 2)
-        #self.assertEqual(im.height, height * 2)
+        # self.assertEqual(im.width, width * 2)
+        # self.assertEqual(im.height, height * 2)
 
         # all-frames should load every frame of the animation
         # (though all-frames is deprecated)
         im = pyvips.Image.magickload(GIF_ANIM_FILE)
         width = im.width
         height = im.height
-        im = pyvips.Image.magickload(GIF_ANIM_FILE, all_frames = True)
+        im = pyvips.Image.magickload(GIF_ANIM_FILE, all_frames=True)
         self.assertEqual(im.width, width)
         self.assertEqual(im.height, height * 5)
 
@@ -354,7 +364,7 @@ class TestForeign(PyvipsTester):
         im = pyvips.Image.magickload(GIF_ANIM_FILE)
         width = im.width
         height = im.height
-        im = pyvips.Image.magickload(GIF_ANIM_FILE, page = 1, n = 2)
+        im = pyvips.Image.magickload(GIF_ANIM_FILE, page=1, n=2)
         self.assertEqual(im.width, width)
         self.assertEqual(im.height, height * 2)
         page_height = im.get_value("page-height")
@@ -365,11 +375,11 @@ class TestForeign(PyvipsTester):
         self.assertEqual(im.width, 128)
         self.assertEqual(im.height, 128)
         # some IMs are 3 bands, some are 1, can't really test
-        #self.assertEqual(im.bands, 1)
+        # self.assertEqual(im.bands, 1)
 
     def test_webp(self):
         if pyvips.type_find("VipsForeign", "webpload") == 0 or \
-            not os.path.isfile(WEBP_FILE):
+                not os.path.isfile(WEBP_FILE):
             print("no webp support, skipping test")
             return
 
@@ -382,19 +392,19 @@ class TestForeign(PyvipsTester):
 
         self.file_loader("webpload", WEBP_FILE, webp_valid)
         self.buffer_loader("webpload_buffer", WEBP_FILE, webp_valid)
-        self.save_load_buffer("webpsave_buffer", "webpload_buffer", 
+        self.save_load_buffer("webpsave_buffer", "webpload_buffer",
                               self.colour, 60)
         self.save_load("%s.webp", self.colour)
 
         # test lossless mode
         im = pyvips.Image.new_from_file(WEBP_FILE)
-        buf = im.webpsave_buffer(lossless = True)
+        buf = im.webpsave_buffer(lossless=True)
         im2 = pyvips.Image.new_from_buffer(buf, "")
         self.assertEqual(im.avg(), im2.avg())
 
         # higher Q should mean a bigger buffer
-        b1 = im.webpsave_buffer(Q = 10)
-        b2 = im.webpsave_buffer(Q = 90)
+        b1 = im.webpsave_buffer(Q=10)
+        b2 = im.webpsave_buffer(Q=90)
         self.assertGreater(len(b2), len(b1))
 
         # try saving an image with an ICC profile and reading it back ... if we
@@ -408,8 +418,8 @@ class TestForeign(PyvipsTester):
             self.assertEqual(p1, p2)
 
             # add tests for exif, xmp, exif
-            # the exif test will need us to be able to walk the header, we can't
-            # just check exif-data
+            # the exif test will need us to be able to walk the header,
+            # we can't just check exif-data
 
             # we can test that exif changes change the output of webpsave
             x = self.colour.copy()
@@ -420,7 +430,7 @@ class TestForeign(PyvipsTester):
 
     def test_analyzeload(self):
         if pyvips.type_find("VipsForeign", "analyzeload") == 0 or \
-            not os.path.isfile(ANALYZE_FILE):
+                not os.path.isfile(ANALYZE_FILE):
             print("no analyze support, skipping test")
             return
 
@@ -435,7 +445,7 @@ class TestForeign(PyvipsTester):
 
     def test_matload(self):
         if pyvips.type_find("VipsForeign", "matload") == 0 or \
-            not os.path.isfile(MATLAB_FILE):
+                not os.path.isfile(MATLAB_FILE):
             print("no matlab support, skipping test")
             return
 
@@ -450,15 +460,15 @@ class TestForeign(PyvipsTester):
 
     def test_openexrload(self):
         if pyvips.type_find("VipsForeign", "openexrload") == 0 or \
-            not os.path.isfile(EXR_FILE):
+                not os.path.isfile(EXR_FILE):
             print("no openexr support, skipping test")
             return
 
         def exr_valid(self, im):
             a = im(10, 10)
-            self.assertAlmostEqualObjects(a, [0.124512, 0.159668, 
-                                              0.040375, 1.0], 
-                                          places = 5)
+            self.assertAlmostEqualObjects(a, [0.124512, 0.159668,
+                                              0.040375, 1.0],
+                                          places=5)
             self.assertEqual(im.width, 610)
             self.assertEqual(im.height, 406)
             self.assertEqual(im.bands, 4)
@@ -467,15 +477,15 @@ class TestForeign(PyvipsTester):
 
     def test_fitsload(self):
         if pyvips.type_find("VipsForeign", "fitsload") == 0 or \
-            not os.path.isfile(FITS_FILE):
+                not os.path.isfile(FITS_FILE):
             print("no fits support, skipping test")
             return
 
         def fits_valid(self, im):
             a = im(10, 10)
             self.assertAlmostEqualObjects(a, [-0.165013, -0.148553, 1.09122,
-                                              -0.942242], 
-                                          places = 5)
+                                              -0.942242],
+                                          places=5)
             self.assertEqual(im.width, 200)
             self.assertEqual(im.height, 200)
             self.assertEqual(im.bands, 4)
@@ -485,7 +495,7 @@ class TestForeign(PyvipsTester):
 
     def test_openslideload(self):
         if pyvips.type_find("VipsForeign", "openslideload") == 0 or \
-            not os.path.isfile(OPENSLIDE_FILE):
+                not os.path.isfile(OPENSLIDE_FILE):
             print("no openslide support, skipping test")
             return
 
@@ -500,7 +510,7 @@ class TestForeign(PyvipsTester):
 
     def test_pdfload(self):
         if pyvips.type_find("VipsForeign", "pdfload") == 0 or \
-            not os.path.isfile(PDF_FILE):
+                not os.path.isfile(PDF_FILE):
             print("no pdf support, skipping test")
             return
 
@@ -515,18 +525,18 @@ class TestForeign(PyvipsTester):
         self.buffer_loader("pdfload_buffer", PDF_FILE, pdf_valid)
 
         im = pyvips.Image.new_from_file(PDF_FILE)
-        x = pyvips.Image.new_from_file(PDF_FILE, scale = 2)
+        x = pyvips.Image.new_from_file(PDF_FILE, scale=2)
         self.assertLess(abs(im.width * 2 - x.width), 2)
         self.assertLess(abs(im.height * 2 - x.height), 2)
 
         im = pyvips.Image.new_from_file(PDF_FILE)
-        x = pyvips.Image.new_from_file(PDF_FILE, dpi = 144)
+        x = pyvips.Image.new_from_file(PDF_FILE, dpi=144)
         self.assertLess(abs(im.width * 2 - x.width), 2)
         self.assertLess(abs(im.height * 2 - x.height), 2)
 
     def test_gifload(self):
         if pyvips.type_find("VipsForeign", "gifload") == 0 or \
-            not os.path.isfile(GIF_FILE):
+                not os.path.isfile(GIF_FILE):
             print("no gif support, skipping test")
             return
 
@@ -540,21 +550,21 @@ class TestForeign(PyvipsTester):
         self.file_loader("gifload", GIF_FILE, gif_valid)
         self.buffer_loader("gifload_buffer", GIF_FILE, gif_valid)
 
-        x1 = pyvips.Image.new_from_file(GIF_ANIM_FILE )
-        x2 = pyvips.Image.new_from_file(GIF_ANIM_FILE, n = 2 )
+        x1 = pyvips.Image.new_from_file(GIF_ANIM_FILE)
+        x2 = pyvips.Image.new_from_file(GIF_ANIM_FILE, n=2)
         self.assertEqual(x2.height, 2 * x1.height)
         page_height = x2.get_value("page-height")
         self.assertEqual(page_height, x1.height)
 
-        x2 = pyvips.Image.new_from_file(GIF_ANIM_FILE, n = -1 )
+        x2 = pyvips.Image.new_from_file(GIF_ANIM_FILE, n=-1)
         self.assertEqual(x2.height, 5 * x1.height)
 
-        x2 = pyvips.Image.new_from_file(GIF_ANIM_FILE, page = 1, n = -1 )
+        x2 = pyvips.Image.new_from_file(GIF_ANIM_FILE, page=1, n=-1)
         self.assertEqual(x2.height, 4 * x1.height)
 
     def test_svgload(self):
         if pyvips.type_find("VipsForeign", "svgload") == 0 or \
-            not os.path.isfile(SVG_FILE):
+                not os.path.isfile(SVG_FILE):
             print("no svg support, skipping test")
             return
 
@@ -574,12 +584,12 @@ class TestForeign(PyvipsTester):
         self.file_loader("svgload", SVG_GZ_FILE, svg_valid)
 
         im = pyvips.Image.new_from_file(SVG_FILE)
-        x = pyvips.Image.new_from_file(SVG_FILE, scale = 2)
+        x = pyvips.Image.new_from_file(SVG_FILE, scale=2)
         self.assertLess(abs(im.width * 2 - x.width), 2)
         self.assertLess(abs(im.height * 2 - x.height), 2)
 
         im = pyvips.Image.new_from_file(SVG_FILE)
-        x = pyvips.Image.new_from_file(SVG_FILE, dpi = 144)
+        x = pyvips.Image.new_from_file(SVG_FILE, dpi=144)
         self.assertLess(abs(im.width * 2 - x.width), 2)
         self.assertLess(abs(im.height * 2 - x.height), 2)
 
@@ -590,7 +600,7 @@ class TestForeign(PyvipsTester):
         self.save_load("%s.mat", self.mono)
 
     def test_ppm(self):
-        if pyvips.type_find("VipsForeign", "ppmload") == 0: 
+        if pyvips.type_find("VipsForeign", "ppmload") == 0:
             print("no PPM support, skipping test")
             return
 
@@ -603,11 +613,11 @@ class TestForeign(PyvipsTester):
             return
 
         self.save_load("%s.hdr", self.colour)
-        self.save_buffer_tempfile("radsave_buffer", ".hdr", 
-                                  self.rad, max_diff = 0)
+        self.save_buffer_tempfile("radsave_buffer", ".hdr",
+                                  self.rad, max_diff=0)
 
     def test_dzsave(self):
-        if pyvips.type_find("VipsForeign", "dzsave") == 0: 
+        if pyvips.type_find("VipsForeign", "dzsave") == 0:
             print("no dzsave support, skipping test")
             return
 
@@ -618,9 +628,9 @@ class TestForeign(PyvipsTester):
         # default deepzoom layout ... we must use png here, since we want to
         # test the overlap for equality
         filename = temp_filename('')
-        self.colour.dzsave(filename, suffix = ".png")
+        self.colour.dzsave(filename, suffix=".png")
 
-        # test horizontal overlap ... expect 256 step, overlap 1 
+        # test horizontal overlap ... expect 256 step, overlap 1
         x = pyvips.Image.new_from_file(filename + "_files/10/0_0.png")
         self.assertEqual(x.width, 255)
         y = pyvips.Image.new_from_file(filename + "_files/10/1_0.png")
@@ -654,7 +664,7 @@ class TestForeign(PyvipsTester):
 
         # default google layout
         filename = temp_filename('')
-        self.colour.dzsave(filename, layout = "google")
+        self.colour.dzsave(filename, layout="google")
 
         # test bottom-right tile ... default is 256x256 tiles, overlap 0
         x = pyvips.Image.new_from_file(filename + "/2/2/3.jpg")
@@ -672,8 +682,8 @@ class TestForeign(PyvipsTester):
         # with overlap 192 tile size 256, we should step by 64 pixels each time
         # so 3x3 tiles exactly
         filename = temp_filename('')
-        self.colour.crop(0, 0, 384, 384).dzsave(filename, layout = "google", 
-                                                overlap = 192, depth = "one")
+        self.colour.crop(0, 0, 384, 384).dzsave(filename, layout="google",
+                                                overlap=192, depth="one")
 
         # test bottom-right tile ... default is 256x256 tiles, overlap 0
         x = pyvips.Image.new_from_file(filename + "/0/2/2.jpg")
@@ -684,8 +694,8 @@ class TestForeign(PyvipsTester):
         shutil.rmtree(filename)
 
         filename = temp_filename('')
-        self.colour.crop(0, 0, 385, 385).dzsave(filename, layout = "google", 
-                                                overlap = 192, depth = "one")
+        self.colour.crop(0, 0, 385, 385).dzsave(filename, layout="google",
+                                                overlap=192, depth="one")
 
         # test bottom-right tile ... default is 256x256 tiles, overlap 0
         x = pyvips.Image.new_from_file(filename + "/0/3/3.jpg")
@@ -697,7 +707,7 @@ class TestForeign(PyvipsTester):
 
         # default zoomify layout
         filename = temp_filename('')
-        self.colour.dzsave(filename, layout = "zoomify")
+        self.colour.dzsave(filename, layout="zoomify")
 
         # 256x256 tiles, no overlap
         self.assertTrue(os.path.exists(filename + "/ImageProperties.xml"))
@@ -715,15 +725,15 @@ class TestForeign(PyvipsTester):
 
         # test compressed zip output
         filename2 = temp_filename('.zip')
-        self.colour.dzsave(filename2, compression = -1)
+        self.colour.dzsave(filename2, compression=-1)
         self.assertLess(os.path.getsize(filename2),
                         os.path.getsize(filename))
         os.unlink(filename2)
         os.unlink(filename)
 
-        # test suffix 
+        # test suffix
         filename = temp_filename('')
-        self.colour.dzsave(filename, suffix = ".png")
+        self.colour.dzsave(filename, suffix=".png")
 
         x = pyvips.Image.new_from_file(filename + "_files/10/0_0.png")
         self.assertEqual(x.width, 255)
@@ -733,7 +743,7 @@ class TestForeign(PyvipsTester):
 
         # test overlap
         filename = temp_filename('')
-        self.colour.dzsave(filename, overlap = 200)
+        self.colour.dzsave(filename, overlap=200)
 
         y = pyvips.Image.new_from_file(filename + "_files/10/1_1.jpeg")
         self.assertEqual(y.width, 654)
@@ -743,7 +753,7 @@ class TestForeign(PyvipsTester):
 
         # test tile-size
         filename = temp_filename('')
-        self.colour.dzsave(filename, tile_size = 512)
+        self.colour.dzsave(filename, tile_size=512)
 
         y = pyvips.Image.new_from_file(filename + "_files/10/0_0.jpeg")
         self.assertEqual(y.width, 513)
@@ -761,11 +771,12 @@ class TestForeign(PyvipsTester):
         with open(filename, 'rb') as f:
             buf1 = f.read()
         os.unlink(filename)
-        buf2 = self.colour.dzsave_buffer(basename = root)
+        buf2 = self.colour.dzsave_buffer(basename=root)
         self.assertEqual(len(buf1), len(buf2))
 
         # we can't test the bytes are exactly equal, the timestamps will be
         # different
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyvips/tests/test_gvalue.py
+++ b/pyvips/tests/test_gvalue.py
@@ -1,6 +1,9 @@
 # vim: set fileencoding=utf-8 :
+import unittest
 
-from .helpers import *
+import pyvips
+from .helpers import PyvipsTester, JPEG_FILE
+
 
 class TestGValue(PyvipsTester):
     def test_bool(self):
@@ -99,6 +102,6 @@ class TestGValue(PyvipsTester):
         value = gv.get()
         self.assertEqual(value, blob)
 
+
 if __name__ == '__main__':
     unittest.main()
-

--- a/pyvips/tests/test_histogram.py
+++ b/pyvips/tests/test_histogram.py
@@ -1,9 +1,11 @@
 # vim: set fileencoding=utf-8 :
+import unittest
 
-from .helpers import *
+import pyvips
+from .helpers import PyvipsTester, JPEG_FILE
+
 
 class TestHistogram(PyvipsTester):
-
     def test_hist_cum(self):
         im = pyvips.Image.identity()
 
@@ -40,7 +42,7 @@ class TestHistogram(PyvipsTester):
         self.assertTrue(im.avg() < im2.avg())
         self.assertTrue(im.deviate() < im2.deviate())
 
-        im3 = im.hist_local(10, 10, max_slope = 3)
+        im3 = im.hist_local(10, 10, max_slope=3)
 
         self.assertEqual(im.width, im2.width)
         self.assertEqual(im.height, im2.height)
@@ -86,14 +88,14 @@ class TestHistogram(PyvipsTester):
         n_set = (msk.avg() * msk.width * msk.height) / 255.0
         pc_set = 100 * n_set / (msk.width * msk.height)
 
-        self.assertAlmostEqual(pc_set, 90, places = 0)
+        self.assertAlmostEqual(pc_set, 90, places=0)
 
     def test_hist_entropy(self):
         im = pyvips.Image.new_from_file(JPEG_FILE).extract_band(1)
 
         ent = im.hist_find().hist_entropy()
 
-        self.assertAlmostEqual(ent, 4.37, places = 2)
+        self.assertAlmostEqual(ent, 4.37, places=2)
 
     def test_stdif(self):
         im = pyvips.Image.new_from_file(JPEG_FILE)
@@ -106,6 +108,6 @@ class TestHistogram(PyvipsTester):
         # new mean should be closer to target mean
         self.assertTrue(abs(im.avg() - 128) > abs(im2.avg() - 128))
 
+
 if __name__ == '__main__':
     unittest.main()
-

--- a/pyvips/tests/test_iofuncs.py
+++ b/pyvips/tests/test_iofuncs.py
@@ -1,9 +1,11 @@
 # vim: set fileencoding=utf-8 :
+import unittest
 
-from .helpers import *
+import pyvips
+from .helpers import PyvipsTester
+
 
 class TestIofuncs(PyvipsTester):
-
     # test the vips7 filename splitter ... this is very fragile and annoying
     # code with lots of cases
     def test_split7(self):
@@ -15,28 +17,28 @@ class TestIofuncs(PyvipsTester):
 
         cases = [
             ["c:\\silly:dir:name\\fr:ed.tif:jpeg:95,,,,c:\\icc\\srgb.icc",
-                ["c:\\silly:dir:name\\fr:ed.tif", 
-                 "jpeg:95,,,,c:\\icc\\srgb.icc"]],
+             ["c:\\silly:dir:name\\fr:ed.tif",
+              "jpeg:95,,,,c:\\icc\\srgb.icc"]],
             ["I180:",
-                ["I180",
-                 ""]],
+             ["I180",
+              ""]],
             ["c:\\silly:",
-                ["c:\\silly",
-                 ""]],
+             ["c:\\silly",
+              ""]],
             ["c:\\program files\\x:hello",
-                ["c:\\program files\\x",
-                 "hello"]],
+             ["c:\\program files\\x",
+              "hello"]],
             ["C:\\fixtures\\2569067123_aca715a2ee_o.jpg",
-                ["C:\\fixtures\\2569067123_aca715a2ee_o.jpg",
-                 ""]]
+             ["C:\\fixtures\\2569067123_aca715a2ee_o.jpg",
+              ""]]
         ]
-            
+
         for case in cases:
             self.assertEqualObjects(split(case[0]), case[1])
 
     def test_new_from_image(self):
-        im = pyvips.Image.mask_ideal(100, 100, 0.5, 
-                                     reject = True, optical = True)
+        im = pyvips.Image.mask_ideal(100, 100, 0.5,
+                                     reject=True, optical=True)
 
         im2 = im.new_from_image(12)
 
@@ -51,10 +53,11 @@ class TestIofuncs(PyvipsTester):
         self.assertEqual(im2.bands, 1)
         self.assertEqual(im2.avg(), 12)
 
-        im2 = im.new_from_image([1,2,3])
+        im2 = im.new_from_image([1, 2, 3])
 
         self.assertEqual(im2.bands, 3)
         self.assertEqual(im2.avg(), 2)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyvips/tests/test_morphology.py
+++ b/pyvips/tests/test_morphology.py
@@ -1,9 +1,11 @@
 # vim: set fileencoding=utf-8 :
+import unittest
 
-from .helpers import *
+import pyvips
+from .helpers import PyvipsTester
+
 
 class TestMorphology(PyvipsTester):
-
     def test_countlines(self):
         im = pyvips.Image.black(100, 100)
         im = im.draw_line(255, 0, 50, 100, 50)
@@ -12,17 +14,17 @@ class TestMorphology(PyvipsTester):
 
     def test_labelregions(self):
         im = pyvips.Image.black(100, 100)
-        im = im.draw_circle(255, 50, 50, 25, fill = True)
-        mask, opts = im.labelregions(segments = True)
+        im = im.draw_circle(255, 50, 50, 25, fill=True)
+        mask, opts = im.labelregions(segments=True)
 
         self.assertEqual(opts['segments'], 3)
         self.assertEqual(mask.max(), 2)
 
     def test_erode(self):
         im = pyvips.Image.black(100, 100)
-        im = im.draw_circle(255, 50, 50, 25, fill = True)
-        im2 = im.erode([[128, 255, 128], 
-                        [255, 255, 255], 
+        im = im.draw_circle(255, 50, 50, 25, fill=True)
+        im2 = im.erode([[128, 255, 128],
+                        [255, 255, 255],
                         [128, 255, 128]])
         self.assertEqual(im.width, im2.width)
         self.assertEqual(im.height, im2.height)
@@ -31,9 +33,9 @@ class TestMorphology(PyvipsTester):
 
     def test_dilate(self):
         im = pyvips.Image.black(100, 100)
-        im = im.draw_circle(255, 50, 50, 25, fill = True)
-        im2 = im.dilate([[128, 255, 128], 
-                         [255, 255, 255], 
+        im = im.draw_circle(255, 50, 50, 25, fill=True)
+        im2 = im.dilate([[128, 255, 128],
+                         [255, 255, 255],
                          [128, 255, 128]])
         self.assertEqual(im.width, im2.width)
         self.assertEqual(im.height, im2.height)
@@ -42,12 +44,13 @@ class TestMorphology(PyvipsTester):
 
     def test_rank(self):
         im = pyvips.Image.black(100, 100)
-        im = im.draw_circle(255, 50, 50, 25, fill = True)
+        im = im.draw_circle(255, 50, 50, 25, fill=True)
         im2 = im.rank(3, 3, 8)
         self.assertEqual(im.width, im2.width)
         self.assertEqual(im.height, im2.height)
         self.assertEqual(im.bands, im2.bands)
         self.assertTrue(im2.avg() > im.avg())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyvips/vimage.py
+++ b/pyvips/vimage.py
@@ -324,11 +324,11 @@ class Image(VipsObject):
     def __getitem__(self, arg):
         if isinstance(arg, slice):
             i = 0
-            if arg.start != None:
+            if arg.start is not None:
                 i = arg.start
 
             n = self.bands - i
-            if arg.stop != None:
+            if arg.stop is not None:
                 if arg.stop < 0:
                     n = self.bands + arg.stop - i
                 else:
@@ -468,14 +468,14 @@ class Image(VipsObject):
 
     def __eq__(self, other):
         # _eq version allows comparison to None
-        if other == None:
+        if other is None:
             return False
 
         return _call_enum(self, other, 'relational', 'equal')
 
     def __ne__(self, other):
         # _eq version allows comparison to None
-        if other == None:
+        if other is None:
             return True
 
         return _call_enum(self, other, 'relational', 'noteq')
@@ -518,7 +518,7 @@ class Image(VipsObject):
                            if not isinstance(x, numbers.Number)), 
                            None)
 
-        if non_number == None:
+        if non_number is None:
             return self.bandjoin_const(other)
         else:
             return Operation.call("bandjoin", [self] + other)

--- a/pyvips/vimage.py
+++ b/pyvips/vimage.py
@@ -5,7 +5,8 @@ from __future__ import division
 import logging
 import numbers
 
-from pyvips import *
+import pyvips
+from pyvips import ffi, vips_lib, Error, to_bytes, to_string
 
 logger = logging.getLogger(__name__)
 
@@ -26,9 +27,9 @@ ffi.cdef('''
 
     VipsImage* vips_image_copy_memory (VipsImage* image);
 
-    GType vips_image_get_typeof (const VipsImage* image, 
+    GType vips_image_get_typeof (const VipsImage* image,
         const char* name);
-    int vips_image_get (const VipsImage* image, 
+    int vips_image_get (const VipsImage* image,
         const char* name, GValue* value_copy);
     void vips_image_set (VipsImage* image, const char* name, GValue* value);
     int vips_image_remove (VipsImage* image, const char* name);
@@ -42,11 +43,13 @@ ffi.cdef('''
 
 ''')
 
+
 # either a single number, or a table of numbers
 def _is_pixel(value):
-    return (isinstance(value, numbers.Number) or 
-            (isinstance(value, list) and not 
-             isinstance(value, package_index['Image'])))
+    return (isinstance(value, numbers.Number) or
+            (isinstance(value, list) and not
+            isinstance(value, pyvips.Image)))
+
 
 # test for rectangular array of something
 def _is_2D(array):
@@ -61,6 +64,7 @@ def _is_2D(array):
 
     return True
 
+
 # https://stackoverflow.com/a/22409540/1480019
 def _with_metaclass(mcls):
     def decorator(cls):
@@ -73,6 +77,7 @@ def _with_metaclass(mcls):
 
     return decorator
 
+
 # apply a function to a thing, or map over a list
 # we often need to do something like (1.0 / other) and need to work for lists
 # as well as scalars
@@ -82,11 +87,13 @@ def _smap(func, x):
     else:
         return func(x)
 
+
 def _call_enum(image, other, base, operation):
     if _is_pixel(other):
-        return Operation.call(base + '_const', image, operation, other)
+        return pyvips.Operation.call(base + '_const', image, operation, other)
     else:
-        return Operation.call(base, image, other, operation)
+        return pyvips.Operation.call(base, image, other, operation)
+
 
 def _run_cmplx(fn, image):
     """Run a complex function on a non-complex image.
@@ -108,7 +115,7 @@ def _run_cmplx(fn, image):
         else:
             new_format = "complex"
 
-        image = image.copy(format = new_format, bands = image.bands / 2)
+        image = image.copy(format=new_format, bands=image.bands / 2)
 
     image = fn(image)
 
@@ -118,22 +125,24 @@ def _run_cmplx(fn, image):
         else:
             new_format = "float"
 
-        image = image.copy(format = new_format, bands = image.bands * 2)
+        image = image.copy(format=new_format, bands=image.bands * 2)
 
     return image
+
 
 # metaclass for Image ... getattr on this implements the class methods
 class ImageType(type):
     def __getattr__(cls, name):
-        # logger.debug('ImageType.__getattr__ {0}'.format(name))
+        # logger.debug('ImageType.__getattr__ %s', name)
 
         def call_function(*args, **kwargs):
-            return Operation.call(name, *args, **kwargs)
+            return pyvips.Operation.call(name, *args, **kwargs)
 
         return call_function
 
+
 @_with_metaclass(ImageType)
-class Image(VipsObject):
+class Image(pyvips.VipsObject):
     # private static
 
     @staticmethod
@@ -147,7 +156,7 @@ class Image(VipsObject):
             return self.new_from_image(value)
 
     def __init__(self, pointer):
-        # logger.debug('Image.__init__: pointer = {0}'.format(pointer))
+        # logger.debug('Image.__init__: pointer = %s', pointer)
         super(Image, self).__init__(pointer)
 
     # constructors
@@ -161,10 +170,11 @@ class Image(VipsObject):
         if name == ffi.NULL:
             raise Error('unable to load from file {0}'.format(vips_filename))
 
-        return Operation.call(to_string(ffi.string(name)), 
-                              to_string(ffi.string(filename)),
-                              string_options = to_string(ffi.string(options)), 
-                              **kwargs)
+        return pyvips.Operation.call(to_string(ffi.string(name)),
+                                     to_string(ffi.string(filename)),
+                                     string_options=to_string(
+                                         ffi.string(options)
+                                     ), **kwargs)
 
     @staticmethod
     def new_from_buffer(data, options, **kwargs):
@@ -172,11 +182,11 @@ class Image(VipsObject):
         if name == ffi.NULL:
             raise Error('unable to load from buffer')
 
-        return Operation.call(to_string(ffi.string(name)), data,
-                              string_options = options, **kwargs)
+        return pyvips.Operation.call(to_string(ffi.string(name)), data,
+                                     string_options=options, **kwargs)
 
     @staticmethod
-    def new_from_array(array, scale = 1.0, offset = 0.0):
+    def new_from_array(array, scale=1.0, offset=0.0):
         if not _is_2D(array):
             array = [array]
 
@@ -192,10 +202,10 @@ class Image(VipsObject):
         vi = vips_lib.vips_image_new_matrix_from_array(width, height, a, n)
         if vi == ffi.NULL:
             raise Error('unable to make image from matrix')
-        image = package_index['Image'](vi)
+        image = pyvips.Image(vi)
 
-        image.set_type(GValue.gdouble_type, "scale", scale)
-        image.set_type(GValue.gdouble_type, "offset", offset)
+        image.set_type(pyvips.GValue.gdouble_type, "scale", scale)
+        image.set_type(pyvips.GValue.gdouble_type, "offset", offset)
 
         return image
 
@@ -205,17 +215,17 @@ class Image(VipsObject):
         if vi == ffi.NULL:
             raise Error('unable to make temp file')
 
-        return package_index['Image'](vi)
+        return pyvips.Image(vi)
 
     def new_from_image(self, value):
         pixel = (Image.black(1, 1) + value).cast(self.format)
         image = pixel.embed(0, 0, self.width, self.height,
-                            extend = "copy")
-        image = image.copy(interpretation = self.interpretation,
-                           xres = self.xres,
-                           yres =  self.yres,
-                           xoffset = self.xoffset,
-                           yoffset = self.yoffset)
+                            extend="copy")
+        image = image.copy(interpretation=self.interpretation,
+                           xres=self.xres,
+                           yres=self.yres,
+                           xoffset=self.xoffset,
+                           yoffset=self.yoffset)
 
         return image
 
@@ -224,7 +234,7 @@ class Image(VipsObject):
         if vi == ffi.NULL:
             raise Error('unable to copy to memory')
 
-        return package_index['Image'](vi)
+        return pyvips.Image(vi)
 
     # writers
 
@@ -236,9 +246,10 @@ class Image(VipsObject):
         if name == ffi.NULL:
             raise Error('unable to write to file {0}'.format(vips_filename))
 
-        return Operation.call(to_string(ffi.string(name)), self, filename,
-                              string_options = to_string(ffi.string(options)), 
-                              **kwargs)
+        return pyvips.Operation.call(to_string(ffi.string(name)), self,
+                                     filename, string_options=to_string(
+                                         ffi.string(options)
+                                     ), **kwargs)
 
     def write_to_buffer(self, format_string, **kwargs):
         format_string = to_bytes(format_string)
@@ -247,9 +258,10 @@ class Image(VipsObject):
         if name == ffi.NULL:
             raise Error('unable to write to buffer')
 
-        return Operation.call(to_string(ffi.string(name)), self,
-                              string_options = to_string(ffi.string(options)), 
-                              **kwargs)
+        return pyvips.Operation.call(to_string(ffi.string(name)), self,
+                                     string_options=to_string(
+                                         ffi.string(options)
+                                     ), **kwargs)
 
     def write(self, other):
         result = vips_lib.vips_image_write(self.pointer, other.pointer)
@@ -262,8 +274,8 @@ class Image(VipsObject):
         return vips_lib.vips_image_get_typeof(self.pointer, to_bytes(name))
 
     def get(self, name):
-        gv = GValue()
-        result = vips_lib.vips_image_get(self.pointer, to_bytes(name), 
+        gv = pyvips.GValue()
+        result = vips_lib.vips_image_get(self.pointer, to_bytes(name),
                                          gv.pointer)
         if result != 0:
             raise Error('unable to get {0}'.format(name))
@@ -271,7 +283,7 @@ class Image(VipsObject):
         return gv.get()
 
     def set_type(self, gtype, name, value):
-        gv = GValue()
+        gv = pyvips.GValue()
         gv.init(gtype)
         gv.set(value)
         vips_lib.vips_image_set(self.pointer, to_bytes(name), gv.pointer)
@@ -284,14 +296,14 @@ class Image(VipsObject):
         return vips_lib.vips_image_remove(self.pointer, to_bytes(name)) != 0
 
     def __getattr__(self, name):
-        # logger.debug('Image.__getattr__ {0}'.format(name))
+        # logger.debug('Image.__getattr__ %s', name)
 
         # look up in props first (but not metadata)
         if super(Image, self).get_typeof(name) != 0:
             return super(Image, self).get(name)
 
         def call_function(*args, **kwargs):
-            return Operation.call(name, self, *args, **kwargs)
+            return pyvips.Operation.call(name, self, *args, **kwargs)
 
         return call_function
 
@@ -317,6 +329,7 @@ class Image(VipsObject):
 
     def __enter__(self):
         return self
+
     def __exit__(self, type, value, traceback):
         pass
 
@@ -345,7 +358,7 @@ class Image(VipsObject):
         if i < 0 or i >= self.bands:
             raise IndexError
 
-        return self.extract_band(i, n = n)
+        return self.extract_band(i, n=n)
 
     # overload () to mean fetch pixel
     def __call__(self, x, y):
@@ -354,7 +367,7 @@ class Image(VipsObject):
     # operator overloads
 
     def __add__(self, other):
-        if isinstance(other, package_index['Image']):
+        if isinstance(other, pyvips.Image):
             return self.add(other)
         else:
             return self.linear(1, other)
@@ -363,7 +376,7 @@ class Image(VipsObject):
         return self.__add__(other)
 
     def __sub__(self, other):
-        if isinstance(other, package_index['Image']):
+        if isinstance(other, pyvips.Image):
             return self.subtract(other)
         else:
             return self.linear(1, _smap(lambda x: -1 * x, other))
@@ -380,10 +393,10 @@ class Image(VipsObject):
     def __rmul__(self, other):
         return self.__mul__(other)
 
-    # a / const has always been a float in vips, so div and truediv are the 
+    # a / const has always been a float in vips, so div and truediv are the
     # same
     def __div__(self, other):
-        if isinstance(other, package_index['Image']):
+        if isinstance(other, pyvips.Image):
             return self.divide(other)
         else:
             return self.linear(_smap(lambda x: 1.0 / x, other), 0)
@@ -398,7 +411,7 @@ class Image(VipsObject):
         return self.__rdiv__(other)
 
     def __floordiv__(self, other):
-        if isinstance(other, package_index['Image']):
+        if isinstance(other, pyvips.Image):
             return self.divide(other).floor()
         else:
             return self.linear(_smap(lambda x: 1.0 / x, other), 0).floor()
@@ -407,7 +420,7 @@ class Image(VipsObject):
         return ((self ** -1) * other).floor()
 
     def __mod__(self, other):
-        if isinstance(other, package_index['Image']):
+        if isinstance(other, pyvips.Image):
             return self.remainder(other)
         else:
             return self.remainder_const(other)
@@ -514,32 +527,32 @@ class Image(VipsObject):
             other = [other]
 
         # if [other] is all numbers, we can use bandjoin_const
-        non_number = next((x for x in other 
-                           if not isinstance(x, numbers.Number)), 
-                           None)
+        non_number = next((x for x in other
+                           if not isinstance(x, numbers.Number)),
+                          None)
 
         if non_number is None:
             return self.bandjoin_const(other)
         else:
-            return Operation.call("bandjoin", [self] + other)
+            return pyvips.Operation.call("bandjoin", [self] + other)
 
     def bandrank(self, other, **kwargs):
         """Band-wise rank filter a set of images."""
         if not isinstance(other, list):
             other = [other]
 
-        return Operation.call("bandrank", [self] + other, **kwargs)
+        return pyvips.Operation.call("bandrank", [self] + other, **kwargs)
 
     def maxpos(self):
         """Return the coordinates of the image maximum."""
-        v, opts = self.max(x = True, y = True)
+        v, opts = self.max(x=True, y=True)
         x = opts['x']
         y = opts['y']
         return v, x, y
 
     def minpos(self):
         """Return the coordinates of the image minimum."""
-        v, opts = self.min(x = True, y = True)
+        v, opts = self.min(x=True, y=True)
         x = opts['x']
         y = opts['y']
         return v, x, y
@@ -636,18 +649,19 @@ class Image(VipsObject):
         """Rotate 270 degrees clockwise."""
         return self.rot('d270')
 
-    # we need different imageize rules for this operator ... we need to 
+    # we need different imageize rules for this operator ... we need to
     # imageize th and el to match each other first
     def ifthenelse(self, th, el, **kwargs):
         for match_image in [th, el, self]:
-            if isinstance(match_image, package_index['Image']):
+            if isinstance(match_image, pyvips.Image):
                 break
 
-        if not isinstance(th, package_index['Image']):
+        if not isinstance(th, pyvips.Image):
             th = Image.imageize(match_image, th)
-        if not isinstance(el, package_index['Image']):
+        if not isinstance(el, pyvips.Image):
             el = Image.imageize(match_image, el)
 
-        return Operation.call("ifthenelse", self, th, el, **kwargs)
+        return pyvips.Operation.call("ifthenelse", self, th, el, **kwargs)
+
 
 __all__ = ['Image']

--- a/pyvips/vinterpolate.py
+++ b/pyvips/vinterpolate.py
@@ -4,7 +4,8 @@ from __future__ import division
 
 import logging
 
-from pyvips import *
+import pyvips
+from pyvips import ffi, vips_lib, Error, to_bytes
 
 logger = logging.getLogger(__name__)
 
@@ -19,15 +20,15 @@ ffi.cdef('''
 
 ''')
 
-class Interpolate(VipsObject):
 
+class Interpolate(pyvips.VipsObject):
     def __init__(self, pointer):
-        # logger.debug('Operation.__init__: pointer = {0}'.format(pointer))
+        # logger.debug('Operation.__init__: pointer = %s', pointer)
         super(Interpolate, self).__init__(pointer)
 
     @staticmethod
     def new(name):
-        # logger.debug('VipsInterpolate.new: name = {0}'.format(name))
+        # logger.debug('VipsInterpolate.new: name = %s', name)
 
         vi = vips_lib.vips_interpolate_new(to_bytes(name))
         if vi == ffi.NULL:

--- a/pyvips/voperation.py
+++ b/pyvips/voperation.py
@@ -51,7 +51,7 @@ def _find_inside(pred, thing):
         for x in thing:
             result = _find_inside(pred, x)
 
-            if result != None:
+            if result is not None:
                 return result
 
     return None

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,10 @@ See:
 https://github.com/jcupitt/pyvips
 """
 
-from setuptools import setup, find_packages
 from codecs import open
 from os import path
+
+from setuptools import setup, find_packages
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
It's work in progress, because I see some errors (with Python 3.6.2 and Windows 10 x64):
<details>
 <summary>Output</summary>

```bash
...............E..........................................................................................................E................E........EFEE......................................
======================================================================
ERROR: test_find_trim (pyvips.tests.test_arithmetic.TestArithmetic)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "S:\Users\KleisAuke\Desktop\pyvips\pyvips\tests\test_arithmetic.py", line 556, in test_find_trim
    left, top, width, height = a.find_trim()
  File "S:\Users\KleisAuke\Desktop\pyvips\pyvips\vimage.py", line 294, in call_function
    return Operation.call(name, self, *args, **kwargs)
  File "S:\Users\KleisAuke\Desktop\pyvips\pyvips\voperation.py", line 126, in call
    raise Error('no such operation {0}'.format(operation_name))
pyvips.base.Error: no such operation find_trim
  VipsOperation: class "find_trim" not found


======================================================================
ERROR: test_text (pyvips.tests.test_create.TestCreate)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "S:\Users\KleisAuke\Desktop\pyvips\pyvips\tests\test_create.py", line 378, in test_text
    im = pyvips.Image.text("Hello, world!")
  File "S:\Users\KleisAuke\Desktop\pyvips\pyvips\vimage.py", line 131, in call_function
    return Operation.call(name, *args, **kwargs)
  File "S:\Users\KleisAuke\Desktop\pyvips\pyvips\voperation.py", line 126, in call
    raise Error('no such operation {0}'.format(operation_name))
pyvips.base.Error: no such operation text
  VipsOperation: class "text" not found


======================================================================
ERROR: test_jpeg (pyvips.tests.test_foreign.TestForeign)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "S:\Users\KleisAuke\Desktop\pyvips\pyvips\tests\test_foreign.py", line 164, in test_jpeg
    os.unlink(filename)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\KLEISA~1\\AppData\\Local\\Temp\\tmppfrg_k3x.jpg'

======================================================================
ERROR: test_rad (pyvips.tests.test_foreign.TestForeign)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "S:\Users\KleisAuke\Desktop\pyvips\pyvips\tests\test_foreign.py", line 607, in test_rad
    self.rad, max_diff = 0)
  File "S:\Users\KleisAuke\Desktop\pyvips\pyvips\tests\test_foreign.py", line 89, in save_buffer_tempfile
    os.unlink(filename)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\KLEISA~1\\AppData\\Local\\Temp\\tmp9rbz3rcj.hdr'

======================================================================
ERROR: test_tiff (pyvips.tests.test_foreign.TestForeign)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "S:\Users\KleisAuke\Desktop\pyvips\pyvips\tests\test_foreign.py", line 216, in test_tiff
    self.save_load_file(".tif", "[squash]", self.onebit, 0)
  File "S:\Users\KleisAuke\Desktop\pyvips\pyvips\tests\test_foreign.py", line 63, in save_load_file
    os.unlink(filename)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\KLEISA~1\\AppData\\Local\\Temp\\tmpqdrknwxt.tif'

======================================================================
ERROR: test_vips (pyvips.tests.test_foreign.TestForeign)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "S:\Users\KleisAuke\Desktop\pyvips\pyvips\tests\test_foreign.py", line 92, in test_vips
    self.save_load_file(".v", "", self.colour, 0)
  File "S:\Users\KleisAuke\Desktop\pyvips\pyvips\tests\test_foreign.py", line 63, in save_load_file
    os.unlink(filename)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\KLEISA~1\\AppData\\Local\\Temp\\tmp28nbvb_o.v'

======================================================================
FAIL: test_svgload (pyvips.tests.test_foreign.TestForeign)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "S:\Users\KleisAuke\Desktop\pyvips\pyvips\tests\test_foreign.py", line 568, in test_svgload
    self.file_loader("svgload", SVG_FILE, svg_valid)
  File "S:\Users\KleisAuke\Desktop\pyvips\pyvips\tests\test_foreign.py", line 25, in file_loader
    validate(self, im)
  File "S:\Users\KleisAuke\Desktop\pyvips\pyvips\tests\test_foreign.py", line 563, in svg_valid
    self.assertAlmostEqualObjects(a, [79, 79, 132, 255])
  File "S:\Users\KleisAuke\Desktop\pyvips\pyvips\tests\helpers.py", line 165, in assertAlmostEqualObjects
    self.assertAlmostEqual(x, y, places = places, msg = msg)
AssertionError: 0.0 != 79 within 4 places : 

----------------------------------------------------------------------
Ran 190 tests in 43.545s

FAILED (errors=6, failures=1)
memory: high-water mark 112.16 MB
```
</details>

Not sure if these errors is due to the `tempfile` module. The first 2 errors could be skipped (should we check for libvips 8.6.0 before executing?).

By the way,
Is `libvips 8.6.0-alpha1` available for Windows x64?