### PR TITLE
Fix debug logging

### DIFF
--- a/pyvips/gvalue.py
+++ b/pyvips/gvalue.py
@@ -187,7 +187,7 @@ class GValue(object):
 
         """
 
-        # logger.debug('GValue.set: self = %s, value = %s', self, value)
+        # logger.debug('GValue.set: value = %s', value)
 
         gtype = self.gvalue.gtype
         fundamental = gobject_lib.g_type_fundamental(gtype)

--- a/pyvips/vimage.py
+++ b/pyvips/vimage.py
@@ -3,7 +3,6 @@
 from __future__ import division
 
 import numbers
-import codecs
 
 import pyvips
 from pyvips import ffi, glib_lib, vips_lib, Error, _to_bytes, \

--- a/pyvips/vobject.py
+++ b/pyvips/vobject.py
@@ -96,7 +96,7 @@ class VipsObject(pyvips.GObject):
     # slow! eeeeew
     def _get_pspec(self, name):
         # logger.debug('VipsObject.get_typeof: self = %s, name = %s',
-        #              self, name)
+        #              str(self), name)
 
         pspec = ffi.new('GParamSpec **')
         argument_class = ffi.new('VipsArgumentClass **')
@@ -121,7 +121,7 @@ class VipsObject(pyvips.GObject):
         """
 
         # logger.debug('VipsObject.get_typeof: self = %s, name = %s',
-        #              self, name)
+        #              str(self), name)
 
         pspec = self._get_pspec(name)
         if pspec is not None:
@@ -142,7 +142,7 @@ class VipsObject(pyvips.GObject):
 
         """
 
-        logger.debug('VipsObject.get: self = %s, name = %s', self, name)
+        logger.debug('VipsObject.get: name = %s', name)
 
         gtype = self.get_typeof(name)
 
@@ -160,8 +160,7 @@ class VipsObject(pyvips.GObject):
 
         """
 
-        logger.debug('VipsObject.set: self = %s, name = %s, value = %s',
-                     self, name, value)
+        logger.debug('VipsObject.set: name = %s, value = %s', name, value)
 
         gtype = self.get_typeof(name)
 


### PR DESCRIPTION
This will fix the "maximum recursion depth exceeded" error when running the test suite (`nosetests`) without setting the logging level to warning (`--logging-level=WARNING`).

`VipsObject.get` was calling [`Image.__repr__`](https://github.com/jcupitt/pyvips/blob/cead977bad1e95f680c0f3c3ab0b9099c4738ca6/pyvips/vimage.py#L727-L730), which in turn was calling `VipsObject.get`. 😅 