### PR TITLE
Using Tox for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 dist
 doc/build
 build
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "nightly"
   - "pypy"
   - "pypy3"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,9 @@ python:
   - "pypy3"
 
 install:
-  - pip install .[test]
+  - pip install tox tox-travis
 
-script: "nosetests --logging-level=WARNING"
+script: "tox"
 
 # the vips7 py binding won't work with pypy, make sure it's off
 before_install:

--- a/setup.py
+++ b/setup.py
@@ -14,23 +14,9 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-
-# py3 does not have execfile()
-# see https://stackoverflow.com/a/41658338/894763
-def _my_execfile(filepath, globals=None, locals=None):
-    if globals is None:
-        globals = {}
-    globals.update({
-        "__file__": filepath,
-        "__name__": "__main__",
-    })
-    with open(filepath, 'rb') as file:
-        exec(compile(file.read(), filepath, 'exec'), globals, locals)
-
-
-# pull in __version__ -- we can't import it, since that would execute
-# __init__.py, which won't run because we haven't installed cffi yet
-_my_execfile(path.join(here, 'pyvips', 'version.py'), globals())
+info = {}
+with open(path.join(here, 'pyvips', 'version.py'), encoding='utf-8') as f:
+    exec(f.read(), info)
 
 test_deps = [
     'nose',
@@ -44,7 +30,7 @@ extras = {
 
 setup(
     name='pyvips',
-    version=__version__,
+    version=info['__version__'],
     description='binding for the libvips image processing library',
     long_description=long_description,
     url='https://github.com/jcupitt/pyvips',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+skipdist = true
+
+envlist = {py27,py33,y34,py35,py36,pypy,pypy3}
+
+[testenv]
+setenv =
+    PYTHONPATH = {toxinidir}:{toxinidir}
+
+commands =
+    pip install -e .[test]
+    nosetests --logging-level=WARNING

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,23 @@
 [tox]
 skipdist = true
 
-envlist = {py27,py33,y34,py35,py36,pypy,pypy3}
+envlist =
+    py{27, 33, 34, 35, 36, 37, py, py3}-test
+    qa
+    doc
+
+[travis]
+python =
+    3.6: doc
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}
 
 commands =
-    pip install -e .[test]
-    nosetests --logging-level=WARNING
+    tests: pip install -e .[test]
+    tests: nosetests --logging-level=WARNING
+    qa: pip install -e .[test]
+    qa: flake8
+    doc: pip install -e .[doc]
+    doc: sphinx-build -n -b html doc doc/build/html


### PR DESCRIPTION
Tox and tox-travis are a good way to help a developer replicating the tests locally.

The sphinx-build could have a `-W` to be nit-picky but it breaks the build. And tox could run `flake8` as well but it would also break.

My goal was to remove `nose` since it an abandonware, but it felt like some kind of cleanup could help first.

Cheers,