### PR TITLE
Run the tests...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,10 @@ matrix:
     - python: nightly
 
 install:
-  - pip install tox tox-travis
+  - pip install .[test]
 
-script: "tox"
+script:
+  - python setup.py test
 
 # the vips7 py binding won't work with pypy, make sure it's off
 before_install:

--- a/tox.ini
+++ b/tox.ini
@@ -8,16 +8,20 @@ envlist =
 
 [travis]
 python =
-    3.6: doc
+    2.7: test
+    3.3: test
+    3.4: test
+    3.5: test
+    3.6: test, doc
+    3.7: test
+    pypy: test
+    pypy3: test
 
 [pytest]
-addopts=--verbose
-log_level=WARNING
+norecursedirs = .eggs tmp* vips-*
+log_level = WARNING
 
 [testenv]
-setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}
-
 commands =
     test: python setup.py test
     qa: pip install -e .[test]


### PR DESCRIPTION
I've realised that something was wrong there with the times spent.

![capture d ecran de 2017-10-04 09-18-48](https://user-images.githubusercontent.com/1388/31184894-4478fb56-a8f0-11e7-95b4-aa18ab4083ad.png)

No tests were running... and tox+tox-travais are failing when the `atexit` call is made by pyvips. Something that doesn't occur locally...

So, this rolls back tox-travis but keeps the rest.