### PR TITLE
Convert unit tests from unittest to pytest + general cleanup

### DIFF
--- a/examples/read_profile.py
+++ b/examples/read_profile.py
@@ -10,7 +10,7 @@ import pyvips
 
 a = pyvips.Image.new_from_file(sys.argv[1])
 
-profile = a.get_value("icc-profile-data")
+profile = a.get("icc-profile-data")
 
 with open('x.icm', 'w') as f:
     f.write(profile)

--- a/pyvips/voperation.py
+++ b/pyvips/voperation.py
@@ -136,12 +136,13 @@ class Operation(pyvips.VipsObject):
 
         # make a thing to quickly get flags from an arg name
         flags_from_name = {}
-        for name, flags in arguments:
-            flags_from_name[name] = flags
 
         # count required input args
         n_required = 0
+
         for name, flags in arguments:
+            flags_from_name[name] = flags
+
             if ((flags & _INPUT) != 0 and
                     (flags & _REQUIRED) != 0 and
                     (flags & _DEPRECATED) == 0):

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ test=pytest
 
 [bdist_wheel]
 universal=1
+
+[tool:pytest]
+norecursedirs=tests/helpers

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ install_deps = [
 test_deps = [
     'cffi>=1.0.0',
     'pytest',
-    'pytest-catchlog',
     'pytest-flake8',
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+import os
+
+sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))

--- a/tests/test_colour.py
+++ b/tests/test_colour.py
@@ -7,13 +7,6 @@ from .helpers import PyvipsTester, JPEG_FILE, SRGB_FILE, \
 
 
 class TestColour(PyvipsTester):
-    def setUp(self):
-        im = pyvips.Image.mask_ideal(100, 100, 0.5,
-                                     reject=True, optical=True)
-        self.colour = im * [1, 2, 3] + [2, 3, 4]
-        self.mono = self.colour.extract_band(1)
-        self.all_images = [self.mono, self.colour]
-
     def test_colourspace(self):
         # mid-grey in Lab ... put 42 in the extra band, it should be copied
         # unmodified

--- a/tests/test_colour.py
+++ b/tests/test_colour.py
@@ -140,9 +140,9 @@ class TestColour(PyvipsTester):
         im3 = im.colourspace(pyvips.Interpretation.SRGB)
         self.assertLess(im2.dE76(im3).max(), 6)
 
-        before_profile = test.get_value("icc-profile-data")
+        before_profile = test.get("icc-profile-data")
         im = test.icc_transform(SRGB_FILE)
-        after_profile = im.get_value("icc-profile-data")
+        after_profile = im.get("icc-profile-data")
         im2 = test.icc_import()
         im3 = im2.colourspace(pyvips.Interpretation.SRGB)
         self.assertLess(im.dE76(im3).max(), 6)

--- a/tests/test_colour.py
+++ b/tests/test_colour.py
@@ -1,12 +1,12 @@
 # vim: set fileencoding=utf-8 :
-import unittest
+import pytest
 
 import pyvips
-from .helpers import PyvipsTester, JPEG_FILE, SRGB_FILE, \
-    colour_colourspaces, mono_colourspaces
+from helpers import JPEG_FILE, SRGB_FILE, colour_colourspaces, \
+    mono_colourspaces, assert_almost_equal_objects
 
 
-class TestColour(PyvipsTester):
+class TestColour:
     def test_colourspace(self):
         # mid-grey in Lab ... put 42 in the extra band, it should be copied
         # unmodified
@@ -17,15 +17,15 @@ class TestColour(PyvipsTester):
         im = test
         for col in colour_colourspaces + [pyvips.Interpretation.LAB]:
             im = im.colourspace(col)
-            self.assertEqual(im.interpretation, col)
+            assert im.interpretation == col
 
             for i in range(0, 4):
                 min_l = im.extract_band(i).min()
                 max_h = im.extract_band(i).max()
-                self.assertAlmostEqual(min_l, max_h)
+                assert pytest.approx(min_l) == max_h
 
             pixel = im(10, 10)
-            self.assertAlmostEqual(pixel[3], 42, places=2)
+            assert pytest.approx(pixel[3], 0.01) == 42
 
         # alpha won't be equal for RGB16, but it should be preserved if we go
         # there and back
@@ -34,7 +34,7 @@ class TestColour(PyvipsTester):
 
         before = test(10, 10)
         after = im(10, 10)
-        self.assertAlmostEqualObjects(before, after, places=1)
+        assert_almost_equal_objects(before, after, threshold=0.1)
 
         # go between every pair of colour spaces
         for start in colour_colourspaces:
@@ -46,13 +46,13 @@ class TestColour(PyvipsTester):
                 before = test(10, 10)
                 after = im3(10, 10)
 
-                self.assertAlmostEqualObjects(before, after, places=1)
+                assert_almost_equal_objects(before, after, threshold=0.1)
 
         # test Lab->XYZ on mid-grey
         # checked against http://www.brucelindbloom.com
         im = test.colourspace(pyvips.Interpretation.XYZ)
         after = im(10, 10)
-        self.assertAlmostEqualObjects(after, [17.5064, 18.4187, 20.0547, 42])
+        assert_almost_equal_objects(after, [17.5064, 18.4187, 20.0547, 42])
 
         # grey->colour->grey should be equal
         for mono_fmt in mono_colourspaces:
@@ -60,20 +60,19 @@ class TestColour(PyvipsTester):
             im = test_grey
             for col in colour_colourspaces + [mono_fmt]:
                 im = im.colourspace(col)
-                self.assertEqual(im.interpretation, col)
+                assert im.interpretation == col
             [before, alpha_before] = test_grey(10, 10)
             [after, alpha_after] = im(10, 10)
-            self.assertLess(abs(alpha_after - alpha_before), 1)
+            assert abs(alpha_after - alpha_before) < 1
             if mono_fmt == pyvips.Interpretation.GREY16:
                 # GREY16 can wind up rather different due to rounding
-                self.assertLess(abs(after - before), 30)
+                assert abs(after - before) < 30
             else:
                 # but 8-bit we should hit exactly
-                self.assertLess(abs(after - before), 1)
+                assert abs(after - before) < 1
 
     # test results from Bruce Lindbloom's calculator:
     # http://www.brucelindbloom.com
-
     def test_dE00(self):
         # put 42 in the extra band, it should be copied unmodified
         reference = pyvips.Image.black(100, 100) + [50, 10, 20, 42]
@@ -83,8 +82,8 @@ class TestColour(PyvipsTester):
 
         difference = reference.dE00(sample)
         result, alpha = difference(10, 10)
-        self.assertAlmostEqual(result, 30.238, places=3)
-        self.assertAlmostEqual(alpha, 42.0, places=3)
+        assert pytest.approx(result, 0.001) == 30.238
+        assert pytest.approx(alpha, 0.001) == 42.0
 
     def test_dE76(self):
         # put 42 in the extra band, it should be copied unmodified
@@ -95,8 +94,8 @@ class TestColour(PyvipsTester):
 
         difference = reference.dE76(sample)
         result, alpha = difference(10, 10)
-        self.assertAlmostEqual(result, 33.166, places=3)
-        self.assertAlmostEqual(alpha, 42.0, places=3)
+        assert pytest.approx(result, 0.001) == 33.166
+        assert pytest.approx(alpha, 0.001) == 42.0
 
     # the vips CMC calculation is based on distance in a colorspace
     # derived from the CMC formula, so it won't match exactly ...
@@ -109,47 +108,48 @@ class TestColour(PyvipsTester):
 
         difference = reference.dECMC(sample)
         result, alpha = difference(10, 10)
-        self.assertLess(abs(result - 4.97), 0.5)
-        self.assertAlmostEqual(alpha, 42.0, places=3)
+        assert abs(result - 4.97) < 0.5
+        assert pytest.approx(alpha, 0.001) == 42.0
 
     def test_icc(self):
         test = pyvips.Image.new_from_file(JPEG_FILE)
 
         im = test.icc_import().icc_export()
-        self.assertLess(im.dE76(test).max(), 6)
+        assert im.dE76(test).max() < 6
 
         im = test.icc_import()
         im2 = im.icc_export(depth=16)
-        self.assertEqual(im2.format, pyvips.BandFormat.USHORT)
+        assert im2.format == pyvips.BandFormat.USHORT
         im3 = im2.icc_import()
-        self.assertLess((im - im3).abs().max(), 3)
+        assert (im - im3).abs().max() < 3
 
         im = test.icc_import(intent=pyvips.Intent.ABSOLUTE)
         im2 = im.icc_export(intent=pyvips.Intent.ABSOLUTE)
-        self.assertLess(im2.dE76(test).max(), 6)
+        assert im2.dE76(test).max() < 6
 
         im = test.icc_import()
         im2 = im.icc_export(output_profile=SRGB_FILE)
         im3 = im.colourspace(pyvips.Interpretation.SRGB)
-        self.assertLess(im2.dE76(im3).max(), 6)
+        assert im2.dE76(im3).max() < 6
 
         before_profile = test.get("icc-profile-data")
         im = test.icc_transform(SRGB_FILE)
         after_profile = im.get("icc-profile-data")
         im2 = test.icc_import()
         im3 = im2.colourspace(pyvips.Interpretation.SRGB)
-        self.assertLess(im.dE76(im3).max(), 6)
-        self.assertNotEqual(len(before_profile), len(after_profile))
+        assert im.dE76(im3).max() < 6
+        assert len(before_profile) != len(after_profile)
 
         im = test.icc_import(input_profile=SRGB_FILE)
         im2 = test.icc_import()
-        self.assertLess(6, im.dE76(im2).max())
+        assert 6 < im.dE76(im2).max()
 
         im = test.icc_import(pcs=pyvips.PCS.XYZ)
-        self.assertEqual(im.interpretation, pyvips.Interpretation.XYZ)
+        assert im.interpretation == pyvips.Interpretation.XYZ
+
         im = test.icc_import()
-        self.assertEqual(im.interpretation, pyvips.Interpretation.LAB)
+        assert im.interpretation == pyvips.Interpretation.LAB
 
 
 if __name__ == '__main__':
-    unittest.main()
+    pytest.main()

--- a/tests/test_convolution.py
+++ b/tests/test_convolution.py
@@ -17,7 +17,7 @@ def conv(image, mask, x_position, y_position):
             p = run_fn2(operator.mul, m, i)
             s = run_fn2(operator.add, s, p)
 
-    return run_fn2(operator.truediv, s, mask.get_scale())
+    return run_fn2(operator.truediv, s, mask.scale)
 
 
 def compass(image, mask, x_position, y_position, n_rot, fn):

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,442 +1,439 @@
 # vim: set fileencoding=utf-8 :
-import unittest
+import pytest
 
 import pyvips
-from .helpers import PyvipsTester
+from helpers import assert_almost_equal_objects
 
 
-class TestCreate(PyvipsTester):
+class TestCreate:
     def test_black(self):
         im = pyvips.Image.black(100, 100)
 
-        self.assertEqual(im.width, 100)
-        self.assertEqual(im.height, 100)
-        self.assertEqual(im.format, pyvips.BandFormat.UCHAR)
-        self.assertEqual(im.bands, 1)
+        assert im.width == 100
+        assert im.height == 100
+        assert im.format == pyvips.BandFormat.UCHAR
+        assert im.bands == 1
         for i in range(0, 100):
             pixel = im(i, i)
-            self.assertEqual(len(pixel), 1)
-            self.assertEqual(pixel[0], 0)
+            assert len(pixel) == 1
+            assert pixel[0] == 0
 
         im = pyvips.Image.black(100, 100, bands=3)
 
-        self.assertEqual(im.width, 100)
-        self.assertEqual(im.height, 100)
-        self.assertEqual(im.format, pyvips.BandFormat.UCHAR)
-        self.assertEqual(im.bands, 3)
+        assert im.width == 100
+        assert im.height == 100
+        assert im.format == pyvips.BandFormat.UCHAR
+        assert im.bands == 3
         for i in range(0, 100):
             pixel = im(i, i)
-            self.assertEqual(len(pixel), 3)
-            self.assertAlmostEqualObjects(pixel, [0, 0, 0])
+            assert len(pixel) == 3
+            assert_almost_equal_objects(pixel, [0, 0, 0])
 
     def test_buildlut(self):
         M = pyvips.Image.new_from_array([[0, 0],
                                          [255, 100]])
         lut = M.buildlut()
-        self.assertEqual(lut.width, 256)
-        self.assertEqual(lut.height, 1)
-        self.assertEqual(lut.bands, 1)
+        assert lut.width == 256
+        assert lut.height == 1
+        assert lut.bands == 1
         p = lut(0, 0)
-        self.assertEqual(p[0], 0.0)
+        assert p[0] == 0.0
         p = lut(255, 0)
-        self.assertEqual(p[0], 100.0)
+        assert p[0] == 100.0
         p = lut(10, 0)
-        self.assertEqual(p[0], 100 * 10.0 / 255.0)
+        assert p[0] == 100 * 10.0 / 255.0
 
         M = pyvips.Image.new_from_array([[0, 0, 100],
                                          [255, 100, 0],
                                          [128, 10, 90]])
         lut = M.buildlut()
-        self.assertEqual(lut.width, 256)
-        self.assertEqual(lut.height, 1)
-        self.assertEqual(lut.bands, 2)
+        assert lut.width == 256
+        assert lut.height == 1
+        assert lut.bands == 2
         p = lut(0, 0)
-        self.assertAlmostEqualObjects(p, [0.0, 100.0])
+        assert_almost_equal_objects(p, [0.0, 100.0])
         p = lut(64, 0)
-        self.assertAlmostEqualObjects(p, [5.0, 95.0])
+        assert_almost_equal_objects(p, [5.0, 95.0])
 
     def test_eye(self):
         im = pyvips.Image.eye(100, 90)
-        self.assertEqual(im.width, 100)
-        self.assertEqual(im.height, 90)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
-        self.assertEqual(im.max(), 1.0)
-        self.assertEqual(im.min(), -1.0)
+        assert im.width == 100
+        assert im.height == 90
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
+        assert im.max() == 1.0
+        assert im.min() == -1.0
 
         im = pyvips.Image.eye(100, 90, uchar=True)
-        self.assertEqual(im.width, 100)
-        self.assertEqual(im.height, 90)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.UCHAR)
-        self.assertEqual(im.max(), 255.0)
-        self.assertEqual(im.min(), 0.0)
+        assert im.width == 100
+        assert im.height == 90
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.UCHAR
+        assert im.max() == 255.0
+        assert im.min() == 0.0
 
     def test_fractsurf(self):
         im = pyvips.Image.fractsurf(100, 90, 2.5)
-        self.assertEqual(im.width, 100)
-        self.assertEqual(im.height, 90)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
+        assert im.width == 100
+        assert im.height == 90
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
 
     def test_gaussmat(self):
         im = pyvips.Image.gaussmat(1, 0.1)
-        self.assertEqual(im.width, 5)
-        self.assertEqual(im.height, 5)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.DOUBLE)
-        self.assertEqual(im.max(), 20)
+        assert im.width == 5
+        assert im.height == 5
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.DOUBLE
+        assert im.max() == 20
         total = im.avg() * im.width * im.height
         scale = im.get("scale")
-        self.assertEqual(total, scale)
+        assert total == scale
         p = im(im.width / 2, im.height / 2)
-        self.assertEqual(p[0], 20.0)
+        assert p[0] == 20.0
 
         im = pyvips.Image.gaussmat(1, 0.1,
                                    separable=True, precision="float")
-        self.assertEqual(im.width, 5)
-        self.assertEqual(im.height, 1)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.DOUBLE)
-        self.assertEqual(im.max(), 1.0)
+        assert im.width == 5
+        assert im.height == 1
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.DOUBLE
+        assert im.max() == 1.0
         total = im.avg() * im.width * im.height
         scale = im.get("scale")
-        self.assertEqual(total, scale)
+        assert total == scale
         p = im(im.width / 2, im.height / 2)
-        self.assertEqual(p[0], 1.0)
+        assert p[0] == 1.0
 
     def test_gaussnoise(self):
         im = pyvips.Image.gaussnoise(100, 90)
-        self.assertEqual(im.width, 100)
-        self.assertEqual(im.height, 90)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
+        assert im.width == 100
+        assert im.height == 90
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
 
         im = pyvips.Image.gaussnoise(100, 90, sigma=10, mean=100)
-        self.assertEqual(im.width, 100)
-        self.assertEqual(im.height, 90)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
+        assert im.width == 100
+        assert im.height == 90
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
 
         sigma = im.deviate()
         mean = im.avg()
 
-        self.assertAlmostEqual(sigma, 10, places=0)
-        self.assertAlmostEqual(mean, 100, places=0)
+        assert pytest.approx(sigma, 0.2) == 10
+        assert pytest.approx(mean, 0.2) == 100
 
     def test_grey(self):
         im = pyvips.Image.grey(100, 90)
-        self.assertEqual(im.width, 100)
-        self.assertEqual(im.height, 90)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
+        assert im.width == 100
+        assert im.height == 90
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
 
         p = im(0, 0)
-        self.assertEqual(p[0], 0.0)
+        assert p[0] == 0.0
         p = im(99, 0)
-        self.assertEqual(p[0], 1.0)
+        assert p[0] == 1.0
         p = im(0, 89)
-        self.assertEqual(p[0], 0.0)
+        assert p[0] == 0.0
         p = im(99, 89)
-        self.assertEqual(p[0], 1.0)
+        assert p[0] == 1.0
 
         im = pyvips.Image.grey(100, 90, uchar=True)
-        self.assertEqual(im.width, 100)
-        self.assertEqual(im.height, 90)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.UCHAR)
+        assert im.width == 100
+        assert im.height == 90
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.UCHAR
 
         p = im(0, 0)
-        self.assertEqual(p[0], 0)
+        assert p[0] == 0
         p = im(99, 0)
-        self.assertEqual(p[0], 255)
+        assert p[0] == 255
         p = im(0, 89)
-        self.assertEqual(p[0], 0)
+        assert p[0] == 0
         p = im(99, 89)
-        self.assertEqual(p[0], 255)
+        assert p[0] == 255
 
     def test_identity(self):
         im = pyvips.Image.identity()
-        self.assertEqual(im.width, 256)
-        self.assertEqual(im.height, 1)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.UCHAR)
+        assert im.width == 256
+        assert im.height == 1
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.UCHAR
 
         p = im(0, 0)
-        self.assertEqual(p[0], 0.0)
+        assert p[0] == 0.0
         p = im(255, 0)
-        self.assertEqual(p[0], 255.0)
+        assert p[0] == 255.0
         p = im(128, 0)
-        self.assertEqual(p[0], 128.0)
+        assert p[0] == 128.0
 
         im = pyvips.Image.identity(ushort=True)
-        self.assertEqual(im.width, 65536)
-        self.assertEqual(im.height, 1)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.USHORT)
+        assert im.width == 65536
+        assert im.height == 1
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.USHORT
 
         p = im(0, 0)
-        self.assertEqual(p[0], 0)
+        assert p[0] == 0
         p = im(99, 0)
-        self.assertEqual(p[0], 99)
+        assert p[0] == 99
         p = im(65535, 0)
-        self.assertEqual(p[0], 65535)
+        assert p[0] == 65535
 
     def test_invertlut(self):
         lut = pyvips.Image.new_from_array([[0.1, 0.2, 0.3, 0.1],
                                            [0.2, 0.4, 0.4, 0.2],
                                            [0.7, 0.5, 0.6, 0.3]])
         im = lut.invertlut()
-        self.assertEqual(im.width, 256)
-        self.assertEqual(im.height, 1)
-        self.assertEqual(im.bands, 3)
-        self.assertEqual(im.format, pyvips.BandFormat.DOUBLE)
+        assert im.width == 256
+        assert im.height == 1
+        assert im.bands == 3
+        assert im.format == pyvips.BandFormat.DOUBLE
 
         p = im(0, 0)
-        self.assertAlmostEqualObjects(p, [0, 0, 0])
+        assert_almost_equal_objects(p, [0, 0, 0])
         p = im(255, 0)
-        self.assertAlmostEqualObjects(p, [1, 1, 1])
+        assert_almost_equal_objects(p, [1, 1, 1])
         p = im(0.2 * 255, 0)
-        self.assertAlmostEqual(p[0], 0.1, places=2)
+        assert pytest.approx(p[0], 0.1) == 0.1
         p = im(0.3 * 255, 0)
-        self.assertAlmostEqual(p[1], 0.1, places=2)
+        assert pytest.approx(p[1], 0.1) == 0.1
         p = im(0.1 * 255, 0)
-        self.assertAlmostEqual(p[2], 0.1, places=2)
+        assert pytest.approx(p[2], 0.1) == 0.1
 
     def test_logmat(self):
         im = pyvips.Image.logmat(1, 0.1)
-        self.assertEqual(im.width, 7)
-        self.assertEqual(im.height, 7)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.DOUBLE)
-        self.assertEqual(im.max(), 20)
+        assert im.width == 7
+        assert im.height == 7
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.DOUBLE
+        assert im.max() == 20
         total = im.avg() * im.width * im.height
         scale = im.get("scale")
-        self.assertEqual(total, scale)
+        assert total == scale
         p = im(im.width / 2, im.height / 2)
-        self.assertEqual(p[0], 20.0)
+        assert p[0] == 20.0
 
         im = pyvips.Image.logmat(1, 0.1,
                                  separable=True, precision="float")
-        self.assertEqual(im.width, 7)
-        self.assertEqual(im.height, 1)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.DOUBLE)
-        self.assertEqual(im.max(), 1.0)
+        assert im.width == 7
+        assert im.height == 1
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.DOUBLE
+        assert im.max() == 1.0
         total = im.avg() * im.width * im.height
         scale = im.get("scale")
-        self.assertEqual(total, scale)
+        assert total == scale
         p = im(im.width / 2, im.height / 2)
-        self.assertEqual(p[0], 1.0)
+        assert p[0] == 1.0
 
     def test_mask_butterworth_band(self):
         im = pyvips.Image.mask_butterworth_band(128, 128, 2,
                                                 0.5, 0.5, 0.7,
                                                 0.1)
-        self.assertEqual(im.width, 128)
-        self.assertEqual(im.height, 128)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
-        self.assertAlmostEqual(im.max(), 1, places=2)
+        assert im.width == 128
+        assert im.height == 128
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
+        assert pytest.approx(im.max(), 0.01) == 1
         p = im(32, 32)
-        self.assertEqual(p[0], 1.0)
+        assert p[0] == 1.0
 
         im = pyvips.Image.mask_butterworth_band(128, 128, 2,
                                                 0.5, 0.5, 0.7,
                                                 0.1, uchar=True, optical=True)
-        self.assertEqual(im.width, 128)
-        self.assertEqual(im.height, 128)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.UCHAR)
-        self.assertEqual(im.max(), 255)
+        assert im.width == 128
+        assert im.height == 128
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.UCHAR
+        assert im.max() == 255
         p = im(32, 32)
-        self.assertEqual(p[0], 255.0)
+        assert p[0] == 255.0
         p = im(64, 64)
-        self.assertEqual(p[0], 255.0)
+        assert p[0] == 255.0
 
         im = pyvips.Image.mask_butterworth_band(128, 128, 2,
                                                 0.5, 0.5, 0.7,
                                                 0.1, uchar=True, optical=True,
                                                 nodc=True)
-        self.assertEqual(im.width, 128)
-        self.assertEqual(im.height, 128)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.UCHAR)
-        self.assertEqual(im.max(), 255)
+        assert im.width == 128
+        assert im.height == 128
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.UCHAR
+        assert im.max() == 255
         p = im(32, 32)
-        self.assertEqual(p[0], 255.0)
+        assert p[0] == 255.0
         p = im(64, 64)
-        self.assertNotEqual(p[0], 255)
+        assert p[0] != 255
 
     def test_mask_butterworth(self):
         im = pyvips.Image.mask_butterworth(128, 128, 2, 0.7, 0.1,
                                            nodc=True)
-        self.assertEqual(im.width, 128)
-        self.assertEqual(im.height, 128)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
-        self.assertAlmostEqual(im.min(), 0, places=2)
+        assert im.width == 128
+        assert im.height == 128
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
+        assert pytest.approx(im.min(), 0.01) == 0
         p = im(0, 0)
-        self.assertEqual(p[0], 0.0)
+        assert p[0] == 0.0
         v, x, y = im.maxpos()
-        self.assertEqual(x, 64)
-        self.assertEqual(y, 64)
+        assert x == 64
+        assert y == 64
 
         im = pyvips.Image.mask_butterworth(128, 128, 2, 0.7, 0.1,
                                            optical=True, uchar=True)
-        self.assertEqual(im.width, 128)
-        self.assertEqual(im.height, 128)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.UCHAR)
-        self.assertAlmostEqual(im.min(), 0, places=2)
+        assert im.width == 128
+        assert im.height == 128
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.UCHAR
+        assert pytest.approx(im.min(), 0.01) == 0
         p = im(64, 64)
-        self.assertEqual(p[0], 255)
+        assert p[0] == 255
 
     def test_mask_butterworth_ring(self):
         im = pyvips.Image.mask_butterworth_ring(128, 128, 2, 0.7, 0.1, 0.5,
                                                 nodc=True)
-        self.assertEqual(im.width, 128)
-        self.assertEqual(im.height, 128)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
+        assert im.width == 128
+        assert im.height == 128
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
         p = im(45, 0)
-        self.assertAlmostEqual(p[0], 1.0, places=4)
+        assert pytest.approx(p[0], 0.0001) == 1.0
         v, x, y = im.minpos()
-        self.assertEqual(x, 64)
-        self.assertEqual(y, 64)
+        assert x == 64
+        assert y == 64
 
     def test_mask_fractal(self):
         im = pyvips.Image.mask_fractal(128, 128, 2.3)
-        self.assertEqual(im.width, 128)
-        self.assertEqual(im.height, 128)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
+        assert im.width == 128
+        assert im.height == 128
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
 
     def test_mask_gaussian_band(self):
         im = pyvips.Image.mask_gaussian_band(128, 128, 0.5, 0.5, 0.7, 0.1)
-        self.assertEqual(im.width, 128)
-        self.assertEqual(im.height, 128)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
-        self.assertAlmostEqual(im.max(), 1, places=2)
+        assert im.width == 128
+        assert im.height == 128
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
+        assert pytest.approx(im.max(), 0.01) == 1
         p = im(32, 32)
-        self.assertEqual(p[0], 1.0)
+        assert p[0] == 1.0
 
     def test_mask_gaussian(self):
         im = pyvips.Image.mask_gaussian(128, 128, 0.7, 0.1,
                                         nodc=True)
-        self.assertEqual(im.width, 128)
-        self.assertEqual(im.height, 128)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
-        self.assertAlmostEqual(im.min(), 0, places=2)
+        assert im.width == 128
+        assert im.height == 128
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
+        assert pytest.approx(im.min(), 0.01) == 0
         p = im(0, 0)
-        self.assertEqual(p[0], 0.0)
+        assert p[0] == 0.0
 
     def test_mask_gaussian_ring(self):
         im = pyvips.Image.mask_gaussian_ring(128, 128, 0.7, 0.1, 0.5,
                                              nodc=True)
-        self.assertEqual(im.width, 128)
-        self.assertEqual(im.height, 128)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
+        assert im.width == 128
+        assert im.height == 128
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
         p = im(45, 0)
-        self.assertAlmostEqual(p[0], 1.0, places=3)
+        assert pytest.approx(p[0], 0.001) == 1.0
 
     def test_mask_ideal_band(self):
         im = pyvips.Image.mask_ideal_band(128, 128, 0.5, 0.5, 0.7)
-        self.assertEqual(im.width, 128)
-        self.assertEqual(im.height, 128)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
-        self.assertAlmostEqual(im.max(), 1, places=2)
+        assert im.width == 128
+        assert im.height == 128
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
+        assert pytest.approx(im.max(), 0.01) == 1
         p = im(32, 32)
-        self.assertEqual(p[0], 1.0)
+        assert p[0] == 1.0
 
     def test_mask_ideal(self):
         im = pyvips.Image.mask_ideal(128, 128, 0.7,
                                      nodc=True)
-        self.assertEqual(im.width, 128)
-        self.assertEqual(im.height, 128)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
-        self.assertAlmostEqual(im.min(), 0, places=2)
+        assert im.width == 128
+        assert im.height == 128
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
+        assert pytest.approx(im.min(), 0.01) == 0
         p = im(0, 0)
-        self.assertEqual(p[0], 0.0)
+        assert p[0] == 0.0
 
     def test_mask_gaussian_ring_2(self):
         im = pyvips.Image.mask_ideal_ring(128, 128, 0.7, 0.5,
                                           nodc=True)
-        self.assertEqual(im.width, 128)
-        self.assertEqual(im.height, 128)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
+        assert im.width == 128
+        assert im.height == 128
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
         p = im(45, 0)
-        self.assertAlmostEqual(p[0], 1.0, places=3)
+        assert pytest.approx(p[0], 0.001) == 1.0
 
     def test_sines(self):
         im = pyvips.Image.sines(128, 128)
-        self.assertEqual(im.width, 128)
-        self.assertEqual(im.height, 128)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
+        assert im.width == 128
+        assert im.height == 128
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
 
+    @pytest.mark.skipif(pyvips.type_find("VipsOperation", "text") == 0,
+                        reason="no text, skipping test")
     def test_text(self):
-        if pyvips.type_find("VipsOperation", "text") != 0:
-            im = pyvips.Image.text("Hello, world!")
-            self.assertTrue(im.width > 10)
-            self.assertTrue(im.height > 10)
-            self.assertEqual(im.bands, 1)
-            self.assertEqual(im.format, pyvips.BandFormat.UCHAR)
-            self.assertEqual(im.max(), 255)
-            self.assertEqual(im.min(), 0)
+        im = pyvips.Image.text("Hello, world!")
+        assert im.width > 10
+        assert im.height > 10
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.UCHAR
+        assert im.max() == 255
+        assert im.min() == 0
 
     def test_tonelut(self):
         im = pyvips.Image.tonelut()
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.USHORT)
-        self.assertEqual(im.width, 32768)
-        self.assertEqual(im.height, 1)
-        self.assertTrue(im.hist_ismonotonic())
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.USHORT
+        assert im.width == 32768
+        assert im.height == 1
+        assert im.hist_ismonotonic()
 
     def test_xyz(self):
         im = pyvips.Image.xyz(128, 128)
-        self.assertEqual(im.bands, 2)
-        self.assertEqual(im.format, pyvips.BandFormat.UINT)
-        self.assertEqual(im.width, 128)
-        self.assertEqual(im.height, 128)
+        assert im.bands == 2
+        assert im.format == pyvips.BandFormat.UINT
+        assert im.width == 128
+        assert im.height == 128
         p = im(45, 35)
-        self.assertAlmostEqualObjects(p, [45, 35])
+        assert_almost_equal_objects(p, [45, 35])
 
     def test_zone(self):
         im = pyvips.Image.zone(128, 128)
-        self.assertEqual(im.width, 128)
-        self.assertEqual(im.height, 128)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
+        assert im.width == 128
+        assert im.height == 128
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
 
+    @pytest.mark.skipif(pyvips.type_find("VipsOperation", "worley") == 0,
+                        reason="no worley, skipping test")
     def test_worley(self):
-        if pyvips.type_find("VipsOperation", "worley") == 0:
-            print("no worley, skipping test")
-            return
-
         im = pyvips.Image.worley(512, 512)
-        self.assertEqual(im.width, 512)
-        self.assertEqual(im.height, 512)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
+        assert im.width == 512
+        assert im.height == 512
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
 
+    @pytest.mark.skipif(pyvips.type_find("VipsOperation", "perlin") == 0,
+                        reason="no perlin, skipping test")
     def test_perlin(self):
-        if pyvips.type_find("VipsOperation", "perlin") == 0:
-            print("no perlin, skipping test")
-            return
-
         im = pyvips.Image.perlin(512, 512)
-        self.assertEqual(im.width, 512)
-        self.assertEqual(im.height, 512)
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.format, pyvips.BandFormat.FLOAT)
+        assert im.width == 512
+        assert im.height == 512
+        assert im.bands == 1
+        assert im.format == pyvips.BandFormat.FLOAT
 
 
 if __name__ == '__main__':
-    unittest.main()
+    pytest.main()

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1,30 +1,29 @@
 # vim: set fileencoding=utf-8 :
-import unittest
+import pytest
 
 import pyvips
-from .helpers import PyvipsTester
 
 
-class TestDraw(PyvipsTester):
+class TestDraw:
     def test_draw_circle(self):
         im = pyvips.Image.black(100, 100)
         im = im.draw_circle(100, 50, 50, 25)
         pixel = im(25, 50)
-        self.assertEqual(len(pixel), 1)
-        self.assertEqual(pixel[0], 100)
+        assert len(pixel) == 1
+        assert pixel[0] == 100
         pixel = im(26, 50)
-        self.assertEqual(len(pixel), 1)
-        self.assertEqual(pixel[0], 0)
+        assert len(pixel) == 1
+        assert pixel[0] == 0
 
         im = pyvips.Image.black(100, 100)
         im = im.draw_circle(100, 50, 50, 25, fill=True)
         pixel = im(25, 50)
-        self.assertEqual(len(pixel), 1)
-        self.assertEqual(pixel[0], 100)
+        assert len(pixel) == 1
+        assert pixel[0] == 100
         pixel = im(26, 50)
-        self.assertEqual(pixel[0], 100)
+        assert pixel[0] == 100
         pixel = im(24, 50)
-        self.assertEqual(pixel[0], 0)
+        assert pixel[0] == 0
 
     def test_draw_flood(self):
         im = pyvips.Image.black(100, 100)
@@ -32,10 +31,10 @@ class TestDraw(PyvipsTester):
         im = im.draw_flood(100, 50, 50)
 
         im2 = pyvips.Image.black(100, 100)
-        im2 = im.draw_circle(100, 50, 50, 25, fill=True)
+        im2 = im2.draw_circle(100, 50, 50, 25, fill=True)
 
         diff = (im - im2).abs().max()
-        self.assertEqual(diff, 0)
+        assert diff == 0
 
     def test_draw_image(self):
         im = pyvips.Image.black(51, 51)
@@ -48,17 +47,17 @@ class TestDraw(PyvipsTester):
         im3 = im3.draw_circle(100, 50, 50, 25, fill=True)
 
         diff = (im2 - im3).abs().max()
-        self.assertEqual(diff, 0)
+        assert diff == 0
 
     def test_draw_line(self):
         im = pyvips.Image.black(100, 100)
         im = im.draw_line(100, 0, 0, 100, 0)
         pixel = im(0, 0)
-        self.assertEqual(len(pixel), 1)
-        self.assertEqual(pixel[0], 100)
+        assert len(pixel) == 1
+        assert pixel[0] == 100
         pixel = im(0, 1)
-        self.assertEqual(len(pixel), 1)
-        self.assertEqual(pixel[0], 0)
+        assert len(pixel) == 1
+        assert pixel[0] == 0
 
     def test_draw_mask(self):
         mask = pyvips.Image.black(51, 51)
@@ -71,7 +70,7 @@ class TestDraw(PyvipsTester):
         im2 = im2.draw_circle(100, 50, 50, 25, fill=True)
 
         diff = (im - im2).abs().max()
-        self.assertEqual(diff, 0)
+        assert diff == 0
 
     def test_draw_rect(self):
         im = pyvips.Image.black(100, 100)
@@ -82,7 +81,7 @@ class TestDraw(PyvipsTester):
             im2 = im2.draw_line(100, 25, y, 74, y)
 
         diff = (im - im2).abs().max()
-        self.assertEqual(diff, 0)
+        assert diff == 0
 
     def test_draw_smudge(self):
         im = pyvips.Image.black(100, 100)
@@ -95,8 +94,8 @@ class TestDraw(PyvipsTester):
         im4 = im2.draw_image(im3, 10, 10)
 
         diff = (im4 - im).abs().max()
-        self.assertEqual(diff, 0)
+        assert diff == 0
 
 
 if __name__ == '__main__':
-    unittest.main()
+    pytest.main()

--- a/tests/test_foreign.py
+++ b/tests/test_foreign.py
@@ -111,8 +111,8 @@ class TestForeign(PyvipsTester):
         filename = temp_filename(self.tempdir, ".v")
         self.colour.write_to_file(filename)
         x = pyvips.Image.new_from_file(filename)
-        before_exif = self.colour.get_value("exif-data")
-        after_exif = x.get_value("exif-data")
+        before_exif = self.colour.get("exif-data")
+        after_exif = x.get("exif-data")
 
         self.assertEqual(len(before_exif), len(after_exif))
         for i in range(len(before_exif)):
@@ -128,7 +128,7 @@ class TestForeign(PyvipsTester):
         def jpeg_valid(self, im):
             a = im(10, 10)
             self.assertAlmostEqualObjects(a, [6, 5, 3])
-            profile = im.get_value("icc-profile-data")
+            profile = im.get("icc-profile-data")
             self.assertEqual(len(profile), 1352)
             self.assertEqual(im.width, 1024)
             self.assertEqual(im.height, 768)
@@ -151,11 +151,11 @@ class TestForeign(PyvipsTester):
             # can set, save and load new orientation
             x = pyvips.Image.new_from_file(JPEG_FILE)
             x = x.copy()
-            x.set_value("orientation", 2)
+            x.set("orientation", 2)
             filename = temp_filename(self.tempdir, '.jpg')
             x.write_to_file(filename)
             x = pyvips.Image.new_from_file(filename)
-            y = x.get_value("orientation")
+            y = x.get("orientation")
             self.assertEqual(y, 2)
 
             # can remove orientation, save, load again, orientation
@@ -164,14 +164,14 @@ class TestForeign(PyvipsTester):
             filename = temp_filename(self.tempdir, '.jpg')
             x.write_to_file(filename)
             x = pyvips.Image.new_from_file(filename)
-            y = x.get_value("orientation")
+            y = x.get("orientation")
             self.assertEqual(y, 1)
 
             # autorotate load works
             filename = temp_filename(self.tempdir, '.jpg')
             x = pyvips.Image.new_from_file(JPEG_FILE)
             x = x.copy()
-            x.set_value("orientation", 6)
+            x.set("orientation", 6)
             x.write_to_file(filename)
             x1 = pyvips.Image.new_from_file(filename)
             x2 = pyvips.Image.new_from_file(filename, autorotate=True)
@@ -240,32 +240,32 @@ class TestForeign(PyvipsTester):
         filename = temp_filename(self.tempdir, '.tif')
         x = pyvips.Image.new_from_file(TIF_FILE)
         x = x.copy()
-        x.set_value("orientation", 2)
+        x.set("orientation", 2)
         x.write_to_file(filename)
         x = pyvips.Image.new_from_file(filename)
-        y = x.get_value("orientation")
+        y = x.get("orientation")
         self.assertEqual(y, 2)
 
         filename = temp_filename(self.tempdir, '.tif')
         x = pyvips.Image.new_from_file(TIF_FILE)
         x = x.copy()
-        x.set_value("orientation", 2)
+        x.set("orientation", 2)
         x.write_to_file(filename)
         x = pyvips.Image.new_from_file(filename)
-        y = x.get_value("orientation")
+        y = x.get("orientation")
         self.assertEqual(y, 2)
         x.remove("orientation")
 
         filename = temp_filename(self.tempdir, '.tif')
         x.write_to_file(filename)
         x = pyvips.Image.new_from_file(filename)
-        y = x.get_value("orientation")
+        y = x.get("orientation")
         self.assertEqual(y, 1)
 
         filename = temp_filename(self.tempdir, '.tif')
         x = pyvips.Image.new_from_file(TIF_FILE)
         x = x.copy()
-        x.set_value("orientation", 6)
+        x.set("orientation", 6)
         x.write_to_file(filename)
         x1 = pyvips.Image.new_from_file(filename)
         x2 = pyvips.Image.new_from_file(filename, autorotate=True)
@@ -373,7 +373,7 @@ class TestForeign(PyvipsTester):
             im = pyvips.Image.magickload(GIF_ANIM_FILE, page=1, n=2)
             self.assertEqual(im.width, width)
             self.assertEqual(im.height, height * 2)
-            page_height = im.get_value("page-height")
+            page_height = im.get("page-height")
             self.assertEqual(page_height, height)
 
         # should work for dicom
@@ -419,8 +419,8 @@ class TestForeign(PyvipsTester):
         im = pyvips.Image.new_from_buffer(buf, "")
         if im.get_typeof("icc-profile-data") != 0:
             # verify that the profile comes back unharmed
-            p1 = self.colour.get_value("icc-profile-data")
-            p2 = im.get_value("icc-profile-data")
+            p1 = self.colour.get("icc-profile-data")
+            p2 = im.get("icc-profile-data")
             self.assertEqual(p1, p2)
 
             # add tests for exif, xmp, ipct
@@ -432,10 +432,10 @@ class TestForeign(PyvipsTester):
             z = pyvips.Image.new_from_file(JPEG_FILE)
             if z.get_typeof("exif-ifd0-Orientation") != 0:
                 x = self.colour.copy()
-                x.set_value("orientation", 6)
+                x.set("orientation", 6)
                 buf = x.webpsave_buffer()
                 y = pyvips.Image.new_from_buffer(buf, "")
-                self.assertEqual(y.get_value("orientation"), 6)
+                self.assertEqual(y.get("orientation"), 6)
 
     def test_analyzeload(self):
         if pyvips.type_find("VipsForeign", "analyzeload") == 0 or \
@@ -564,7 +564,7 @@ class TestForeign(PyvipsTester):
             x1 = pyvips.Image.new_from_file(GIF_ANIM_FILE)
             x2 = pyvips.Image.new_from_file(GIF_ANIM_FILE, n=2)
             self.assertEqual(x2.height, 2 * x1.height)
-            page_height = x2.get_value("page-height")
+            page_height = x2.get("page-height")
             self.assertEqual(page_height, x1.height)
 
             x2 = pyvips.Image.new_from_file(GIF_ANIM_FILE, n=-1)

--- a/tests/test_foreign.py
+++ b/tests/test_foreign.py
@@ -1,69 +1,67 @@
 # vim: set fileencoding=utf-8 :
-
 import gc
 import os
 import shutil
 import tempfile
-import unittest
+import pytest
 
 import pyvips
-from .helpers import PyvipsTester, JPEG_FILE, SRGB_FILE, \
+from helpers import JPEG_FILE, SRGB_FILE, \
     MATLAB_FILE, PNG_FILE, TIF_FILE, OME_FILE, ANALYZE_FILE, \
     GIF_FILE, WEBP_FILE, EXR_FILE, FITS_FILE, OPENSLIDE_FILE, \
     PDF_FILE, SVG_FILE, SVGZ_FILE, SVG_GZ_FILE, GIF_ANIM_FILE, \
-    DICOM_FILE, temp_filename
+    DICOM_FILE, temp_filename, assert_almost_equal_objects
 
 
-class TestForeign(PyvipsTester):
+class TestForeign:
     tempdir = None
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.tempdir = tempfile.mkdtemp()
 
-    def setUp(self):
-        self.colour = pyvips.Image.jpegload(JPEG_FILE)
-        self.mono = self.colour.extract_band(1)
+        cls.colour = pyvips.Image.jpegload(JPEG_FILE)
+        cls.mono = cls.colour.extract_band(1)
         # we remove the ICC profile: the RGB one will no longer be appropriate
-        self.mono.remove("icc-profile-data")
-        self.rad = self.colour.float2rad()
-        self.rad.remove("icc-profile-data")
-        self.cmyk = self.colour.bandjoin(self.mono)
-        self.cmyk = self.cmyk.copy(interpretation=pyvips.Interpretation.CMYK)
-        self.cmyk.remove("icc-profile-data")
+        cls.mono.remove("icc-profile-data")
+        cls.rad = cls.colour.float2rad()
+        cls.rad.remove("icc-profile-data")
+        cls.cmyk = cls.colour.bandjoin(cls.mono)
+        cls.cmyk = cls.cmyk.copy(interpretation=pyvips.Interpretation.CMYK)
+        cls.cmyk.remove("icc-profile-data")
 
         im = pyvips.Image.new_from_file(GIF_FILE)
-        self.onebit = im > 128
+        cls.onebit = im > 128
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         shutil.rmtree(cls.tempdir, ignore_errors=True)
 
     # we have test files for formats which have a clear standard
     def file_loader(self, loader, test_file, validate):
         im = pyvips.Operation.call(loader, test_file)
-        validate(self, im)
+        validate(im)
         im = pyvips.Image.new_from_file(test_file)
-        validate(self, im)
+        validate(im)
 
     def buffer_loader(self, loader, test_file, validate):
         with open(test_file, 'rb') as f:
             buf = f.read()
 
         im = pyvips.Operation.call(loader, buf)
-        validate(self, im)
+        validate(im)
         im = pyvips.Image.new_from_buffer(buf, "")
-        validate(self, im)
+        validate(im)
 
     def save_load(self, format, im):
         x = pyvips.Image.new_temp_file(format)
         im.write(x)
 
-        self.assertEqual(im.width, x.width)
-        self.assertEqual(im.height, x.height)
-        self.assertEqual(im.bands, x.bands)
+        assert im.width == x.width
+        assert im.height == x.height
+        assert im.bands == x.bands
         max_diff = (im - x).abs().max()
-        self.assertEqual(max_diff, 0)
+        assert max_diff == 0
 
     def save_load_file(self, format, options, im, thresh):
         # yuk!
@@ -73,21 +71,21 @@ class TestForeign(PyvipsTester):
         im.write_to_file(filename + options)
         x = pyvips.Image.new_from_file(filename)
 
-        self.assertEqual(im.width, x.width)
-        self.assertEqual(im.height, x.height)
-        self.assertEqual(im.bands, x.bands)
+        assert im.width == x.width
+        assert im.height == x.height
+        assert im.bands == x.bands
         max_diff = (im - x).abs().max()
-        self.assertTrue(max_diff <= thresh)
+        assert max_diff <= thresh
         x = None
 
     def save_load_buffer(self, saver, loader, im, max_diff=0):
         buf = pyvips.Operation.call(saver, im)
         x = pyvips.Operation.call(loader, buf)
 
-        self.assertEqual(im.width, x.width)
-        self.assertEqual(im.height, x.height)
-        self.assertEqual(im.bands, x.bands)
-        self.assertLessEqual((im - x).abs().max(), max_diff)
+        assert im.width == x.width
+        assert im.height == x.height
+        assert im.bands == x.bands
+        assert (im - x).abs().max() <= max_diff
 
     def save_buffer_tempfile(self, saver, suf, im, max_diff=0):
         filename = temp_filename(self.tempdir, suf)
@@ -99,10 +97,10 @@ class TestForeign(PyvipsTester):
 
         x = pyvips.Image.new_from_file(filename)
 
-        self.assertEqual(im.width, x.width)
-        self.assertEqual(im.height, x.height)
-        self.assertEqual(im.bands, x.bands)
-        self.assertLessEqual((im - x).abs().max(), max_diff)
+        assert im.width == x.width
+        assert im.height == x.height
+        assert im.bands == x.bands
+        assert (im - x).abs().max() <= max_diff
 
     def test_vips(self):
         self.save_load_file(".v", "", self.colour, 0)
@@ -114,25 +112,23 @@ class TestForeign(PyvipsTester):
         before_exif = self.colour.get("exif-data")
         after_exif = x.get("exif-data")
 
-        self.assertEqual(len(before_exif), len(after_exif))
+        assert len(before_exif) == len(after_exif)
         for i in range(len(before_exif)):
-            self.assertEqual(before_exif[i], after_exif[i])
+            assert before_exif[i] == after_exif[i]
 
         x = None
 
+    @pytest.mark.skipif(pyvips.type_find("VipsForeign", "jpegload") == 0,
+                        reason="no jpeg support in this vips, skipping test")
     def test_jpeg(self):
-        if pyvips.type_find("VipsForeign", "jpegload") == 0:
-            print("no jpeg support in this vips, skipping test")
-            return
-
-        def jpeg_valid(self, im):
+        def jpeg_valid(im):
             a = im(10, 10)
-            self.assertAlmostEqualObjects(a, [6, 5, 3])
+            assert_almost_equal_objects(a, [6, 5, 3])
             profile = im.get("icc-profile-data")
-            self.assertEqual(len(profile), 1352)
-            self.assertEqual(im.width, 1024)
-            self.assertEqual(im.height, 768)
-            self.assertEqual(im.bands, 3)
+            assert len(profile) == 1352
+            assert im.width == 1024
+            assert im.height == 768
+            assert im.bands == 3
 
         self.file_loader("jpegload", JPEG_FILE, jpeg_valid)
         self.save_load("%s.jpg", self.mono)
@@ -156,7 +152,7 @@ class TestForeign(PyvipsTester):
             x.write_to_file(filename)
             x = pyvips.Image.new_from_file(filename)
             y = x.get("orientation")
-            self.assertEqual(y, 2)
+            assert y == 2
 
             # can remove orientation, save, load again, orientation
             # has reset
@@ -165,7 +161,7 @@ class TestForeign(PyvipsTester):
             x.write_to_file(filename)
             x = pyvips.Image.new_from_file(filename)
             y = x.get("orientation")
-            self.assertEqual(y, 1)
+            assert y == 1
 
             # autorotate load works
             filename = temp_filename(self.tempdir, '.jpg')
@@ -175,21 +171,19 @@ class TestForeign(PyvipsTester):
             x.write_to_file(filename)
             x1 = pyvips.Image.new_from_file(filename)
             x2 = pyvips.Image.new_from_file(filename, autorotate=True)
-            self.assertEqual(x1.width, x2.height)
-            self.assertEqual(x1.height, x2.width)
+            assert x1.width == x2.height
+            assert x1.height == x2.width
 
+    @pytest.mark.skipif(pyvips.type_find("VipsForeign", "pngload") == 0 or
+                        not os.path.isfile(PNG_FILE),
+                        reason="no png support, skipping test")
     def test_png(self):
-        if pyvips.type_find("VipsForeign", "pngload") == 0 or \
-                not os.path.isfile(PNG_FILE):
-            print("no png support, skipping test")
-            return
-
-        def png_valid(self, im):
+        def png_valid(im):
             a = im(10, 10)
-            self.assertAlmostEqualObjects(a, [38671.0, 33914.0, 26762.0])
-            self.assertEqual(im.width, 290)
-            self.assertEqual(im.height, 442)
-            self.assertEqual(im.bands, 3)
+            assert_almost_equal_objects(a, [38671.0, 33914.0, 26762.0])
+            assert im.width == 290
+            assert im.height == 442
+            assert im.bands == 3
 
         self.file_loader("pngload", PNG_FILE, png_valid)
         self.buffer_loader("pngload_buffer", PNG_FILE, png_valid)
@@ -197,18 +191,16 @@ class TestForeign(PyvipsTester):
         self.save_load("%s.png", self.mono)
         self.save_load("%s.png", self.colour)
 
+    @pytest.mark.skipif(pyvips.type_find("VipsForeign", "tiffload") == 0 or
+                        not os.path.isfile(TIF_FILE),
+                        reason="no tiff support, skipping test")
     def test_tiff(self):
-        if pyvips.type_find("VipsForeign", "tiffload") == 0 or \
-                not os.path.isfile(TIF_FILE):
-            print("no tiff support, skipping test")
-            return
-
-        def tiff_valid(self, im):
+        def tiff_valid(im):
             a = im(10, 10)
-            self.assertAlmostEqualObjects(a, [38671.0, 33914.0, 26762.0])
-            self.assertEqual(im.width, 290)
-            self.assertEqual(im.height, 442)
-            self.assertEqual(im.bands, 3)
+            assert_almost_equal_objects(a, [38671.0, 33914.0, 26762.0])
+            assert im.width == 290
+            assert im.height == 442
+            assert im.bands == 3
 
         self.file_loader("tiffload", TIF_FILE, tiff_valid)
         self.buffer_loader("tiffload_buffer", TIF_FILE, tiff_valid)
@@ -244,7 +236,7 @@ class TestForeign(PyvipsTester):
         x.write_to_file(filename)
         x = pyvips.Image.new_from_file(filename)
         y = x.get("orientation")
-        self.assertEqual(y, 2)
+        assert y == 2
 
         filename = temp_filename(self.tempdir, '.tif')
         x = pyvips.Image.new_from_file(TIF_FILE)
@@ -253,14 +245,14 @@ class TestForeign(PyvipsTester):
         x.write_to_file(filename)
         x = pyvips.Image.new_from_file(filename)
         y = x.get("orientation")
-        self.assertEqual(y, 2)
+        assert y == 2
         x.remove("orientation")
 
         filename = temp_filename(self.tempdir, '.tif')
         x.write_to_file(filename)
         x = pyvips.Image.new_from_file(filename)
         y = x.get("orientation")
-        self.assertEqual(y, 1)
+        assert y == 1
 
         filename = temp_filename(self.tempdir, '.tif')
         x = pyvips.Image.new_from_file(TIF_FILE)
@@ -269,42 +261,42 @@ class TestForeign(PyvipsTester):
         x.write_to_file(filename)
         x1 = pyvips.Image.new_from_file(filename)
         x2 = pyvips.Image.new_from_file(filename, autorotate=True)
-        self.assertEqual(x1.width, x2.height)
-        self.assertEqual(x1.height, x2.width)
+        assert x1.width == x2.height
+        assert x1.height == x2.width
 
         # OME support in 8.5
         if pyvips.at_least_libvips(8, 5):
             x = pyvips.Image.new_from_file(OME_FILE)
-            self.assertEqual(x.width, 439)
-            self.assertEqual(x.height, 167)
+            assert x.width == 439
+            assert x.height == 167
             page_height = x.height
 
             x = pyvips.Image.new_from_file(OME_FILE, n=-1)
-            self.assertEqual(x.width, 439)
-            self.assertEqual(x.height, page_height * 15)
+            assert x.width == 439
+            assert x.height == page_height * 15
 
             x = pyvips.Image.new_from_file(OME_FILE, page=1, n=-1)
-            self.assertEqual(x.width, 439)
-            self.assertEqual(x.height, page_height * 14)
+            assert x.width == 439
+            assert x.height == page_height * 14
 
             x = pyvips.Image.new_from_file(OME_FILE, page=1, n=2)
-            self.assertEqual(x.width, 439)
-            self.assertEqual(x.height, page_height * 2)
+            assert x.width == 439
+            assert x.height == page_height * 2
 
             x = pyvips.Image.new_from_file(OME_FILE, n=-1)
-            self.assertEqual(x(0, 166)[0], 96)
-            self.assertEqual(x(0, 167)[0], 0)
-            self.assertEqual(x(0, 168)[0], 1)
+            assert x(0, 166)[0] == 96
+            assert x(0, 167)[0] == 0
+            assert x(0, 168)[0] == 1
 
             filename = temp_filename(self.tempdir, '.tif')
             x.write_to_file(filename)
 
             x = pyvips.Image.new_from_file(filename, n=-1)
-            self.assertEqual(x.width, 439)
-            self.assertEqual(x.height, page_height * 15)
-            self.assertEqual(x(0, 166)[0], 96)
-            self.assertEqual(x(0, 167)[0], 0)
-            self.assertEqual(x(0, 168)[0], 1)
+            assert x.width == 439
+            assert x.height == page_height * 15
+            assert x(0, 166)[0] == 96
+            assert x(0, 167)[0] == 0
+            assert x(0, 168)[0] == 1
 
         # pyr save to buffer added in 8.6
         if pyvips.at_least_libvips(8, 6):
@@ -314,36 +306,34 @@ class TestForeign(PyvipsTester):
             x.tiffsave(filename, tile=True, pyramid=True)
             with open(filename, 'rb') as f:
                 buf2 = f.read()
-            self.assertEqual(len(buf), len(buf2))
+            assert len(buf) == len(buf2)
 
             a = pyvips.Image.new_from_buffer(buf, "", page=2)
             b = pyvips.Image.new_from_buffer(buf2, "", page=2)
-            self.assertEqual(a.width, b.width)
-            self.assertEqual(a.height, b.height)
-            self.assertEqual(a.avg(), b.avg())
+            assert a.width == b.width
+            assert a.height == b.height
+            assert a.avg() == b.avg()
 
+    @pytest.mark.skipif(pyvips.type_find("VipsForeign", "magickload") == 0 or
+                        not os.path.isfile(GIF_FILE),
+                        reason="no magick support, skipping test")
     def test_magickload(self):
-        if pyvips.type_find("VipsForeign", "magickload") == 0 or \
-                not os.path.isfile(GIF_FILE):
-            print("no magick support, skipping test")
-            return
-
-        def gif_valid(self, im):
+        def gif_valid(im):
             # some libMagick produce an RGB for this image, some a mono, some
             # rgba, some have a valid alpha, some don't :-(
             # therefore ... just test channel 0
             a = im(10, 10)[0]
 
-            self.assertAlmostEqual(a, 33)
-            self.assertEqual(im.width, 159)
-            self.assertEqual(im.height, 203)
+            assert pytest.approx(a) == 33
+            assert im.width == 159
+            assert im.height == 203
 
         self.file_loader("magickload", GIF_FILE, gif_valid)
         self.buffer_loader("magickload_buffer", GIF_FILE, gif_valid)
 
         # we should have rgba for svg files
         im = pyvips.Image.magickload(SVG_FILE)
-        self.assertEqual(im.bands, 4)
+        assert im.bands == 4
 
         # density should change size of generated svg
         im = pyvips.Image.magickload(SVG_FILE, density='100')
@@ -352,8 +342,8 @@ class TestForeign(PyvipsTester):
         im = pyvips.Image.magickload(SVG_FILE, density='200')
         # This seems to fail on travis, no idea why, some problem in their IM
         # perhaps
-        # self.assertEqual(im.width, width * 2)
-        # self.assertEqual(im.height, height * 2)
+        # assert im.width == width * 2
+        # assert im.height == height * 2
 
         # all-frames should load every frame of the animation
         # (though all-frames is deprecated)
@@ -361,8 +351,8 @@ class TestForeign(PyvipsTester):
         width = im.width
         height = im.height
         im = pyvips.Image.magickload(GIF_ANIM_FILE, all_frames=True)
-        self.assertEqual(im.width, width)
-        self.assertEqual(im.height, height * 5)
+        assert im.width == width
+        assert im.height == height * 5
 
         # page/n let you pick a range of pages
         # 'n' param added in 8.5
@@ -371,30 +361,28 @@ class TestForeign(PyvipsTester):
             width = im.width
             height = im.height
             im = pyvips.Image.magickload(GIF_ANIM_FILE, page=1, n=2)
-            self.assertEqual(im.width, width)
-            self.assertEqual(im.height, height * 2)
+            assert im.width == width
+            assert im.height == height * 2
             page_height = im.get("page-height")
-            self.assertEqual(page_height, height)
+            assert page_height == height
 
         # should work for dicom
         im = pyvips.Image.magickload(DICOM_FILE)
-        self.assertEqual(im.width, 128)
-        self.assertEqual(im.height, 128)
+        assert im.width == 128
+        assert im.height == 128
         # some IMs are 3 bands, some are 1, can't really test
-        # self.assertEqual(im.bands, 1)
+        # assert im.bands == 1
 
+    @pytest.mark.skipif(pyvips.type_find("VipsForeign", "webpload") == 0 or
+                        not os.path.isfile(WEBP_FILE),
+                        reason="no webp support, skipping test")
     def test_webp(self):
-        if pyvips.type_find("VipsForeign", "webpload") == 0 or \
-                not os.path.isfile(WEBP_FILE):
-            print("no webp support, skipping test")
-            return
-
-        def webp_valid(self, im):
+        def webp_valid(im):
             a = im(10, 10)
-            self.assertAlmostEqualObjects(a, [71, 166, 236])
-            self.assertEqual(im.width, 550)
-            self.assertEqual(im.height, 368)
-            self.assertEqual(im.bands, 3)
+            assert_almost_equal_objects(a, [71, 166, 236])
+            assert im.width == 550
+            assert im.height == 368
+            assert im.bands == 3
 
         self.file_loader("webpload", WEBP_FILE, webp_valid)
         self.buffer_loader("webpload_buffer", WEBP_FILE, webp_valid)
@@ -406,12 +394,12 @@ class TestForeign(PyvipsTester):
         im = pyvips.Image.new_from_file(WEBP_FILE)
         buf = im.webpsave_buffer(lossless=True)
         im2 = pyvips.Image.new_from_buffer(buf, "")
-        self.assertEqual(im.avg(), im2.avg())
+        assert im.avg() == im2.avg()
 
         # higher Q should mean a bigger buffer
         b1 = im.webpsave_buffer(Q=10)
         b2 = im.webpsave_buffer(Q=90)
-        self.assertGreater(len(b2), len(b1))
+        assert len(b2) > len(b1)
 
         # try saving an image with an ICC profile and reading it back ... if we
         # can do it, our webp supports metadata load/save
@@ -421,7 +409,7 @@ class TestForeign(PyvipsTester):
             # verify that the profile comes back unharmed
             p1 = self.colour.get("icc-profile-data")
             p2 = im.get("icc-profile-data")
-            self.assertEqual(p1, p2)
+            assert p1 == p2
 
             # add tests for exif, xmp, ipct
             # the exif test will need us to be able to walk the header,
@@ -435,126 +423,111 @@ class TestForeign(PyvipsTester):
                 x.set("orientation", 6)
                 buf = x.webpsave_buffer()
                 y = pyvips.Image.new_from_buffer(buf, "")
-                self.assertEqual(y.get("orientation"), 6)
+                assert y.get("orientation") == 6
 
+    @pytest.mark.skipif(pyvips.type_find("VipsForeign", "analyzeload") == 0 or
+                        not os.path.isfile(ANALYZE_FILE),
+                        reason="no analyze support, skipping test")
     def test_analyzeload(self):
-        if pyvips.type_find("VipsForeign", "analyzeload") == 0 or \
-                not os.path.isfile(ANALYZE_FILE):
-            print("no analyze support, skipping test")
-            return
-
-        def analyze_valid(self, im):
+        def analyze_valid(im):
             a = im(10, 10)
-            self.assertAlmostEqual(a[0], 3335)
-            self.assertEqual(im.width, 128)
-            self.assertEqual(im.height, 8064)
-            self.assertEqual(im.bands, 1)
+            assert pytest.approx(a[0]) == 3335
+            assert im.width == 128
+            assert im.height == 8064
+            assert im.bands == 1
 
         self.file_loader("analyzeload", ANALYZE_FILE, analyze_valid)
 
+    @pytest.mark.skipif(pyvips.type_find("VipsForeign", "matload") == 0 or
+                        not os.path.isfile(MATLAB_FILE),
+                        reason="no matlab support, skipping test")
     def test_matload(self):
-        if pyvips.type_find("VipsForeign", "matload") == 0 or \
-                not os.path.isfile(MATLAB_FILE):
-            print("no matlab support, skipping test")
-            return
-
-        def matlab_valid(self, im):
+        def matlab_valid(im):
             a = im(10, 10)
-            self.assertAlmostEqualObjects(a, [38671.0, 33914.0, 26762.0])
-            self.assertEqual(im.width, 290)
-            self.assertEqual(im.height, 442)
-            self.assertEqual(im.bands, 3)
+            assert_almost_equal_objects(a, [38671.0, 33914.0, 26762.0])
+            assert im.width == 290
+            assert im.height == 442
+            assert im.bands == 3
 
         self.file_loader("matload", MATLAB_FILE, matlab_valid)
 
+    @pytest.mark.skipif(pyvips.type_find("VipsForeign", "openexrload") == 0 or
+                        not os.path.isfile(EXR_FILE),
+                        reason="no openexr support, skipping test")
     def test_openexrload(self):
-        if pyvips.type_find("VipsForeign", "openexrload") == 0 or \
-                not os.path.isfile(EXR_FILE):
-            print("no openexr support, skipping test")
-            return
-
-        def exr_valid(self, im):
+        def exr_valid(im):
             a = im(10, 10)
-            self.assertAlmostEqualObjects(a, [0.124512, 0.159668,
-                                              0.040375, 1.0],
-                                          places=5)
-            self.assertEqual(im.width, 610)
-            self.assertEqual(im.height, 406)
-            self.assertEqual(im.bands, 4)
+            assert_almost_equal_objects(a, [0.124512, 0.159668,
+                                            0.040375, 1.0],
+                                        threshold=0.00001)
+            assert im.width == 610
+            assert im.height == 406
+            assert im.bands == 4
 
         self.file_loader("openexrload", EXR_FILE, exr_valid)
 
+    @pytest.mark.skipif(pyvips.type_find("VipsForeign", "fitsload") == 0 or
+                        not os.path.isfile(FITS_FILE),
+                        reason="no fits support, skipping test")
     def test_fitsload(self):
-        if pyvips.type_find("VipsForeign", "fitsload") == 0 or \
-                not os.path.isfile(FITS_FILE):
-            print("no fits support, skipping test")
-            return
-
-        def fits_valid(self, im):
+        def fits_valid(im):
             a = im(10, 10)
-            self.assertAlmostEqualObjects(a, [-0.165013, -0.148553, 1.09122,
-                                              -0.942242],
-                                          places=5)
-            self.assertEqual(im.width, 200)
-            self.assertEqual(im.height, 200)
-            self.assertEqual(im.bands, 4)
+            assert_almost_equal_objects(a, [-0.165013, -0.148553, 1.09122,
+                                            -0.942242], threshold=0.00001)
+            assert im.width == 200
+            assert im.height == 200
+            assert im.bands == 4
 
         self.file_loader("fitsload", FITS_FILE, fits_valid)
         self.save_load("%s.fits", self.mono)
 
+    @pytest.mark.skipif(pyvips.type_find("VipsForeign", "openslideload") == 0 or  # noqa: E501
+                        not os.path.isfile(OPENSLIDE_FILE),
+                        reason="no openslide support, skipping test")
     def test_openslideload(self):
-        if pyvips.type_find("VipsForeign", "openslideload") == 0 or \
-                not os.path.isfile(OPENSLIDE_FILE):
-            print("no openslide support, skipping test")
-            return
-
-        def openslide_valid(self, im):
+        def openslide_valid(im):
             a = im(10, 10)
-            self.assertAlmostEqualObjects(a, [244, 250, 243, 255])
-            self.assertEqual(im.width, 2220)
-            self.assertEqual(im.height, 2967)
-            self.assertEqual(im.bands, 4)
+            assert_almost_equal_objects(a, [244, 250, 243, 255])
+            assert im.width == 2220
+            assert im.height == 2967
+            assert im.bands == 4
 
         self.file_loader("openslideload", OPENSLIDE_FILE, openslide_valid)
 
+    @pytest.mark.skipif(pyvips.type_find("VipsForeign", "pdfload") == 0 or
+                        not os.path.isfile(PDF_FILE),
+                        reason="no pdf support, skipping test")
     def test_pdfload(self):
-        if pyvips.type_find("VipsForeign", "pdfload") == 0 or \
-                not os.path.isfile(PDF_FILE):
-            print("no pdf support, skipping test")
-            return
-
-        def pdf_valid(self, im):
+        def pdf_valid(im):
             a = im(10, 10)
-            self.assertAlmostEqualObjects(a, [35, 31, 32, 255])
-            self.assertEqual(im.width, 1133)
-            self.assertEqual(im.height, 680)
-            self.assertEqual(im.bands, 4)
+            assert_almost_equal_objects(a, [35, 31, 32, 255])
+            assert im.width == 1133
+            assert im.height == 680
+            assert im.bands == 4
 
         self.file_loader("pdfload", PDF_FILE, pdf_valid)
         self.buffer_loader("pdfload_buffer", PDF_FILE, pdf_valid)
 
         im = pyvips.Image.new_from_file(PDF_FILE)
         x = pyvips.Image.new_from_file(PDF_FILE, scale=2)
-        self.assertLess(abs(im.width * 2 - x.width), 2)
-        self.assertLess(abs(im.height * 2 - x.height), 2)
+        assert abs(im.width * 2 - x.width) < 2
+        assert abs(im.height * 2 - x.height) < 2
 
         im = pyvips.Image.new_from_file(PDF_FILE)
         x = pyvips.Image.new_from_file(PDF_FILE, dpi=144)
-        self.assertLess(abs(im.width * 2 - x.width), 2)
-        self.assertLess(abs(im.height * 2 - x.height), 2)
+        assert abs(im.width * 2 - x.width) < 2
+        assert abs(im.height * 2 - x.height) < 2
 
+    @pytest.mark.skipif(pyvips.type_find("VipsForeign", "gifload") == 0 or
+                        not os.path.isfile(GIF_FILE),
+                        reason="no gif support, skipping test")
     def test_gifload(self):
-        if pyvips.type_find("VipsForeign", "gifload") == 0 or \
-                not os.path.isfile(GIF_FILE):
-            print("no gif support, skipping test")
-            return
-
-        def gif_valid(self, im):
+        def gif_valid(im):
             a = im(10, 10)
-            self.assertAlmostEqualObjects(a, [33])
-            self.assertEqual(im.width, 159)
-            self.assertEqual(im.height, 203)
-            self.assertEqual(im.bands, 1)
+            assert_almost_equal_objects(a, [33])
+            assert im.width == 159
+            assert im.height == 203
+            assert im.bands == 1
 
         self.file_loader("gifload", GIF_FILE, gif_valid)
         self.buffer_loader("gifload_buffer", GIF_FILE, gif_valid)
@@ -563,34 +536,32 @@ class TestForeign(PyvipsTester):
         if pyvips.at_least_libvips(8, 5):
             x1 = pyvips.Image.new_from_file(GIF_ANIM_FILE)
             x2 = pyvips.Image.new_from_file(GIF_ANIM_FILE, n=2)
-            self.assertEqual(x2.height, 2 * x1.height)
+            assert x2.height == 2 * x1.height
             page_height = x2.get("page-height")
-            self.assertEqual(page_height, x1.height)
+            assert page_height == x1.height
 
             x2 = pyvips.Image.new_from_file(GIF_ANIM_FILE, n=-1)
-            self.assertEqual(x2.height, 5 * x1.height)
+            assert x2.height == 5 * x1.height
 
             x2 = pyvips.Image.new_from_file(GIF_ANIM_FILE, page=1, n=-1)
-            self.assertEqual(x2.height, 4 * x1.height)
+            assert x2.height == 4 * x1.height
 
+    @pytest.mark.skipif(pyvips.type_find("VipsForeign", "svgload") == 0 or
+                        not os.path.isfile(SVG_FILE),
+                        reason="no svg support, skipping test")
     def test_svgload(self):
-        if pyvips.type_find("VipsForeign", "svgload") == 0 or \
-                not os.path.isfile(SVG_FILE):
-            print("no svg support, skipping test")
-            return
-
-        def svg_valid(self, im):
+        def svg_valid(im):
             a = im(10, 10)
 
             # some old rsvg versions are way, way off
-            self.assertLess(abs(a[0] - 79), 2)
-            self.assertLess(abs(a[1] - 79), 2)
-            self.assertLess(abs(a[2] - 132), 2)
-            self.assertLess(abs(a[3] - 255), 2)
+            assert abs(a[0] - 79) < 2
+            assert abs(a[1] - 79) < 2
+            assert abs(a[2] - 132) < 2
+            assert abs(a[3] - 255) < 2
 
-            self.assertEqual(im.width, 288)
-            self.assertEqual(im.height, 470)
-            self.assertEqual(im.bands, 4)
+            assert im.width == 288
+            assert im.height == 470
+            assert im.bands == 4
 
         self.file_loader("svgload", SVG_FILE, svg_valid)
         self.buffer_loader("svgload_buffer", SVG_FILE, svg_valid)
@@ -602,13 +573,13 @@ class TestForeign(PyvipsTester):
 
         im = pyvips.Image.new_from_file(SVG_FILE)
         x = pyvips.Image.new_from_file(SVG_FILE, scale=2)
-        self.assertLess(abs(im.width * 2 - x.width), 2)
-        self.assertLess(abs(im.height * 2 - x.height), 2)
+        assert abs(im.width * 2 - x.width) < 2
+        assert abs(im.height * 2 - x.height) < 2
 
         im = pyvips.Image.new_from_file(SVG_FILE)
         x = pyvips.Image.new_from_file(SVG_FILE, dpi=144)
-        self.assertLess(abs(im.width * 2 - x.width), 2)
-        self.assertLess(abs(im.height * 2 - x.height), 2)
+        assert abs(im.width * 2 - x.width) < 2
+        assert abs(im.height * 2 - x.height) < 2
 
     def test_csv(self):
         self.save_load("%s.csv", self.mono)
@@ -616,28 +587,22 @@ class TestForeign(PyvipsTester):
     def test_matrix(self):
         self.save_load("%s.mat", self.mono)
 
+    @pytest.mark.skipif(pyvips.type_find("VipsForeign", "ppmload") == 0,
+                        reason="no PPM support, skipping test")
     def test_ppm(self):
-        if pyvips.type_find("VipsForeign", "ppmload") == 0:
-            print("no PPM support, skipping test")
-            return
-
         self.save_load("%s.ppm", self.mono)
         self.save_load("%s.ppm", self.colour)
 
+    @pytest.mark.skipif(pyvips.type_find("VipsForeign", "radload") == 0,
+                        reason="no Radiance support, skipping test")
     def test_rad(self):
-        if pyvips.type_find("VipsForeign", "radload") == 0:
-            print("no Radiance support, skipping test")
-            return
-
         self.save_load("%s.hdr", self.colour)
         self.save_buffer_tempfile("radsave_buffer", ".hdr",
                                   self.rad, max_diff=0)
 
+    @pytest.mark.skipif(pyvips.type_find("VipsForeign", "dzsave") == 0,
+                        reason="no dzsave support, skipping test")
     def test_dzsave(self):
-        if pyvips.type_find("VipsForeign", "dzsave") == 0:
-            print("no dzsave support, skipping test")
-            return
-
         # dzsave is hard to test, there are so many options
         # test each option separately and hope they all function together
         # correctly
@@ -649,32 +614,32 @@ class TestForeign(PyvipsTester):
 
         # test horizontal overlap ... expect 256 step, overlap 1
         x = pyvips.Image.new_from_file(filename + "_files/10/0_0.png")
-        self.assertEqual(x.width, 255)
+        assert x.width == 255
         y = pyvips.Image.new_from_file(filename + "_files/10/1_0.png")
-        self.assertEqual(y.width, 256)
+        assert y.width == 256
 
         # the right two columns of x should equal the left two columns of y
         left = x.crop(x.width - 2, 0, 2, x.height)
         right = y.crop(0, 0, 2, y.height)
-        self.assertEqual((left - right).abs().max(), 0)
+        assert (left - right).abs().max() == 0
 
         # test vertical overlap
-        self.assertEqual(x.height, 255)
+        assert x.height == 255
         y = pyvips.Image.new_from_file(filename + "_files/10/0_1.png")
-        self.assertEqual(y.height, 256)
+        assert y.height == 256
 
         # the bottom two rows of x should equal the top two rows of y
         top = x.crop(0, x.height - 2, x.width, 2)
         bottom = y.crop(0, 0, y.width, 2)
-        self.assertEqual((top - bottom).abs().max(), 0)
+        assert (top - bottom).abs().max() == 0
 
         # there should be a bottom layer
         x = pyvips.Image.new_from_file(filename + "_files/0/0_0.png")
-        self.assertEqual(x.width, 1)
-        self.assertEqual(x.height, 1)
+        assert x.width == 1
+        assert x.height == 1
 
         # 10 should be the final layer
-        self.assertFalse(os.path.isdir(filename + "_files/11"))
+        assert not os.path.isdir(filename + "_files/11")
 
         # default google layout
         filename = temp_filename(self.tempdir, '')
@@ -682,13 +647,13 @@ class TestForeign(PyvipsTester):
 
         # test bottom-right tile ... default is 256x256 tiles, overlap 0
         x = pyvips.Image.new_from_file(filename + "/2/2/3.jpg")
-        self.assertEqual(x.width, 256)
-        self.assertEqual(x.height, 256)
-        self.assertFalse(os.path.exists(filename + "/2/2/4.jpg"))
-        self.assertFalse(os.path.exists(filename + "/3"))
+        assert x.width == 256
+        assert x.height == 256
+        assert not os.path.exists(filename + "/2/2/4.jpg")
+        assert not os.path.exists(filename + "/3")
         x = pyvips.Image.new_from_file(filename + "/blank.png")
-        self.assertEqual(x.width, 256)
-        self.assertEqual(x.height, 256)
+        assert x.width == 256
+        assert x.height == 256
 
         # google layout with overlap ... verify that we clip correctly
 
@@ -699,9 +664,9 @@ class TestForeign(PyvipsTester):
                                                 overlap=1, depth="one")
 
         x = pyvips.Image.new_from_file(filename + "/0/1/1.jpg")
-        self.assertEqual(x.width, 256)
-        self.assertEqual(x.height, 256)
-        self.assertFalse(os.path.exists(filename + "/0/2/2.jpg"))
+        assert x.width == 256
+        assert x.height == 256
+        assert not os.path.exists(filename + "/0/2/2.jpg")
 
         # with 511x511, it'll fit exactly into 2x2 -- we we actually generate
         # 3x3, since we output the overlaps
@@ -712,19 +677,19 @@ class TestForeign(PyvipsTester):
                                                     overlap=1, depth="one")
 
             x = pyvips.Image.new_from_file(filename + "/0/2/2.jpg")
-            self.assertEqual(x.width, 256)
-            self.assertEqual(x.height, 256)
-            self.assertFalse(os.path.exists(filename + "/0/3/3.jpg"))
+            assert x.width == 256
+            assert x.height == 256
+            assert not os.path.exists(filename + "/0/3/3.jpg")
 
         # default zoomify layout
         filename = temp_filename(self.tempdir, '')
         self.colour.dzsave(filename, layout="zoomify")
 
         # 256x256 tiles, no overlap
-        self.assertTrue(os.path.exists(filename + "/ImageProperties.xml"))
+        assert os.path.exists(filename + "/ImageProperties.xml")
         x = pyvips.Image.new_from_file(filename + "/TileGroup0/2-3-2.jpg")
-        self.assertEqual(x.width, 256)
-        self.assertEqual(x.height, 256)
+        assert x.width == 256
+        assert x.height == 256
 
         # test zip output
         filename = temp_filename(self.tempdir, '.zip')
@@ -733,9 +698,9 @@ class TestForeign(PyvipsTester):
         # disc
         if not pyvips.base.at_least_libvips(8, 6):
             gc.collect()
-        self.assertTrue(os.path.exists(filename))
-        self.assertFalse(os.path.exists(filename + "_files"))
-        self.assertFalse(os.path.exists(filename + ".dzi"))
+        assert os.path.exists(filename)
+        assert not os.path.exists(filename + "_files")
+        assert not os.path.exists(filename + ".dzi")
 
         # test compressed zip output
         filename2 = temp_filename(self.tempdir, '.zip')
@@ -744,31 +709,30 @@ class TestForeign(PyvipsTester):
         # disc
         if not pyvips.base.at_least_libvips(8, 6):
             gc.collect()
-        self.assertTrue(os.path.exists(filename2))
-        self.assertLess(os.path.getsize(filename2),
-                        os.path.getsize(filename))
+        assert os.path.exists(filename2)
+        assert os.path.getsize(filename2) < os.path.getsize(filename)
 
         # test suffix
         filename = temp_filename(self.tempdir, '')
         self.colour.dzsave(filename, suffix=".png")
 
         x = pyvips.Image.new_from_file(filename + "_files/10/0_0.png")
-        self.assertEqual(x.width, 255)
+        assert x.width == 255
 
         # test overlap
         filename = temp_filename(self.tempdir, '')
         self.colour.dzsave(filename, overlap=200)
 
         y = pyvips.Image.new_from_file(filename + "_files/10/1_1.jpeg")
-        self.assertEqual(y.width, 654)
+        assert y.width == 654
 
         # test tile-size
         filename = temp_filename(self.tempdir, '')
         self.colour.dzsave(filename, tile_size=512)
 
         y = pyvips.Image.new_from_file(filename + "_files/10/0_0.jpeg")
-        self.assertEqual(y.width, 513)
-        self.assertEqual(y.height, 513)
+        assert y.width == 513
+        assert y.height == 513
 
         # test save to memory buffer
         if pyvips.type_find("VipsForeign", "dzsave_buffer") != 0:
@@ -784,11 +748,11 @@ class TestForeign(PyvipsTester):
             with open(filename, 'rb') as f:
                 buf1 = f.read()
             buf2 = self.colour.dzsave_buffer(basename=root)
-            self.assertEqual(len(buf1), len(buf2))
+            assert len(buf1) == len(buf2)
 
             # we can't test the bytes are exactly equal -- the timestamps will
             # be different
 
 
 if __name__ == '__main__':
-    unittest.main()
+    pytest.main()

--- a/tests/test_gvalue.py
+++ b/tests/test_gvalue.py
@@ -1,35 +1,35 @@
 # vim: set fileencoding=utf-8 :
-import unittest
+import pytest
 
 import pyvips
-from .helpers import PyvipsTester, JPEG_FILE
+from helpers import JPEG_FILE, assert_almost_equal_objects
 
 
-class TestGValue(PyvipsTester):
+class TestGValue:
     def test_bool(self):
         gv = pyvips.GValue()
         gv.set_type(pyvips.GValue.gbool_type)
         gv.set(True)
         value = gv.get()
-        self.assertEqual(value, True)
+        assert value
 
         gv.set(False)
         value = gv.get()
-        self.assertEqual(value, False)
+        assert not value
 
     def test_int(self):
         gv = pyvips.GValue()
         gv.set_type(pyvips.GValue.gint_type)
         gv.set(12)
         value = gv.get()
-        self.assertEqual(value, 12)
+        assert value == 12
 
     def test_double(self):
         gv = pyvips.GValue()
         gv.set_type(pyvips.GValue.gdouble_type)
         gv.set(3.1415)
         value = gv.get()
-        self.assertEqual(value, 3.1415)
+        assert value == 3.1415
 
     def test_enum(self):
         # the Interpretation enum is created when the first image is made --
@@ -41,7 +41,7 @@ class TestGValue(PyvipsTester):
         gv.set_type(interpretation_gtype)
         gv.set('xyz')
         value = gv.get()
-        self.assertEqual(value, 'xyz')
+        assert value == 'xyz'
 
     def test_flags(self):
         # the OperationFlags enum is created when the first op is made --
@@ -53,28 +53,28 @@ class TestGValue(PyvipsTester):
         gv.set_type(operationflags_gtype)
         gv.set(12)
         value = gv.get()
-        self.assertEqual(value, 12)
+        assert value == 12
 
     def test_string(self):
         gv = pyvips.GValue()
         gv.set_type(pyvips.GValue.gstr_type)
         gv.set('banana')
         value = gv.get()
-        self.assertEqual(value, 'banana')
+        assert value == 'banana'
 
     def test_array_int(self):
         gv = pyvips.GValue()
         gv.set_type(pyvips.GValue.array_int_type)
         gv.set([1, 2, 3])
         value = gv.get()
-        self.assertAlmostEqualObjects(value, [1, 2, 3])
+        assert_almost_equal_objects(value, [1, 2, 3])
 
     def test_array_double(self):
         gv = pyvips.GValue()
         gv.set_type(pyvips.GValue.array_double_type)
         gv.set([1.1, 2.1, 3.1])
         value = gv.get()
-        self.assertAlmostEqualObjects(value, [1.1, 2.1, 3.1])
+        assert_almost_equal_objects(value, [1.1, 2.1, 3.1])
 
     def test_image(self):
         image = pyvips.Image.new_from_file(JPEG_FILE)
@@ -82,7 +82,7 @@ class TestGValue(PyvipsTester):
         gv.set_type(pyvips.GValue.image_type)
         gv.set(image)
         value = gv.get()
-        self.assertEqual(value, image)
+        assert value == image
 
     def test_array_image(self):
         image = pyvips.Image.new_from_file(JPEG_FILE)
@@ -91,7 +91,7 @@ class TestGValue(PyvipsTester):
         gv.set_type(pyvips.GValue.array_image_type)
         gv.set([r, g, b])
         value = gv.get()
-        self.assertEqual(value, [r, g, b])
+        assert value, [r, g == b]
 
     def test_blob(self):
         with open(JPEG_FILE, 'rb') as f:
@@ -100,8 +100,8 @@ class TestGValue(PyvipsTester):
         gv.set_type(pyvips.GValue.blob_type)
         gv.set(blob)
         value = gv.get()
-        self.assertEqual(value, blob)
+        assert value == blob
 
 
 if __name__ == '__main__':
-    unittest.main()
+    pytest.main()

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1,11 +1,11 @@
 # vim: set fileencoding=utf-8 :
-import unittest
+import pytest
 
 import pyvips
-from .helpers import PyvipsTester, JPEG_FILE
+from helpers import JPEG_FILE
 
 
-class TestHistogram(PyvipsTester):
+class TestHistogram:
     def test_hist_cum(self):
         im = pyvips.Image.identity()
 
@@ -14,41 +14,41 @@ class TestHistogram(PyvipsTester):
         cum = im.hist_cum()
 
         p = cum(255, 0)
-        self.assertEqual(p[0], sum)
+        assert p[0] == sum
 
     def test_hist_equal(self):
         im = pyvips.Image.new_from_file(JPEG_FILE)
 
         im2 = im.hist_equal()
 
-        self.assertEqual(im.width, im2.width)
-        self.assertEqual(im.height, im2.height)
+        assert im.width == im2.width
+        assert im.height == im2.height
 
-        self.assertTrue(im.avg() < im2.avg())
-        self.assertTrue(im.deviate() < im2.deviate())
+        assert im.avg() < im2.avg()
+        assert im.deviate() < im2.deviate()
 
     def test_hist_ismonotonic(self):
         im = pyvips.Image.identity()
-        self.assertTrue(im.hist_ismonotonic())
+        assert im.hist_ismonotonic()
 
     def test_hist_local(self):
         im = pyvips.Image.new_from_file(JPEG_FILE)
 
         im2 = im.hist_local(10, 10)
 
-        self.assertEqual(im.width, im2.width)
-        self.assertEqual(im.height, im2.height)
+        assert im.width == im2.width
+        assert im.height == im2.height
 
-        self.assertTrue(im.avg() < im2.avg())
-        self.assertTrue(im.deviate() < im2.deviate())
+        assert im.avg() < im2.avg()
+        assert im.deviate() < im2.deviate()
 
         if pyvips.at_least_libvips(8, 5):
             im3 = im.hist_local(10, 10, max_slope=3)
 
-            self.assertEqual(im.width, im3.width)
-            self.assertEqual(im.height, im3.height)
+            assert im.width == im3.width
+            assert im.height == im3.height
 
-            self.assertTrue(im3.deviate() < im2.deviate())
+            assert im3.deviate() < im2.deviate()
 
     def test_hist_match(self):
         im = pyvips.Image.identity()
@@ -56,29 +56,29 @@ class TestHistogram(PyvipsTester):
 
         matched = im.hist_match(im2)
 
-        self.assertEqual((im - matched).abs().max(), 0.0)
+        assert (im - matched).abs().max() == 0.0
 
     def test_hist_norm(self):
         im = pyvips.Image.identity()
         im2 = im.hist_norm()
 
-        self.assertEqual((im - im2).abs().max(), 0.0)
+        assert (im - im2).abs().max() == 0.0
 
     def test_hist_plot(self):
         im = pyvips.Image.identity()
         im2 = im.hist_plot()
 
-        self.assertEqual(im2.width, 256)
-        self.assertEqual(im2.height, 256)
-        self.assertEqual(im2.format, pyvips.BandFormat.UCHAR)
-        self.assertEqual(im2.bands, 1)
+        assert im2.width == 256
+        assert im2.height == 256
+        assert im2.format == pyvips.BandFormat.UCHAR
+        assert im2.bands == 1
 
     def test_hist_map(self):
         im = pyvips.Image.identity()
 
         im2 = im.maplut(im)
 
-        self.assertEqual((im - im2).abs().max(), 0.0)
+        assert (im - im2).abs().max() == 0.0
 
     def test_percent(self):
         im = pyvips.Image.new_from_file(JPEG_FILE).extract_band(1)
@@ -89,26 +89,26 @@ class TestHistogram(PyvipsTester):
         n_set = (msk.avg() * msk.width * msk.height) / 255.0
         pc_set = 100 * n_set / (msk.width * msk.height)
 
-        self.assertAlmostEqual(pc_set, 90, places=0)
+        assert pytest.approx(pc_set, 0.5) == 90
 
     def test_hist_entropy(self):
         im = pyvips.Image.new_from_file(JPEG_FILE).extract_band(1)
 
         ent = im.hist_find().hist_entropy()
 
-        self.assertAlmostEqual(ent, 4.37, places=2)
+        assert pytest.approx(ent, 0.01) == 4.37
 
     def test_stdif(self):
         im = pyvips.Image.new_from_file(JPEG_FILE)
 
         im2 = im.stdif(10, 10)
 
-        self.assertEqual(im.width, im2.width)
-        self.assertEqual(im.height, im2.height)
+        assert im.width == im2.width
+        assert im.height == im2.height
 
         # new mean should be closer to target mean
-        self.assertTrue(abs(im.avg() - 128) > abs(im2.avg() - 128))
+        assert abs(im.avg() - 128) > abs(im2.avg() - 128)
 
 
 if __name__ == '__main__':
-    unittest.main()
+    pytest.main()

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -45,8 +45,8 @@ class TestHistogram(PyvipsTester):
         if pyvips.at_least_libvips(8, 5):
             im3 = im.hist_local(10, 10, max_slope=3)
 
-            self.assertEqual(im.width, im2.width)
-            self.assertEqual(im.height, im2.height)
+            self.assertEqual(im.width, im3.width)
+            self.assertEqual(im.height, im3.height)
 
             self.assertTrue(im3.deviate() < im2.deviate())
 

--- a/tests/test_iofuncs.py
+++ b/tests/test_iofuncs.py
@@ -1,11 +1,11 @@
 # vim: set fileencoding=utf-8 :
-import unittest
+import pytest
 
 import pyvips
-from .helpers import PyvipsTester
+from helpers import assert_equal_objects
 
 
-class TestIofuncs(PyvipsTester):
+class TestIofuncs:
     # test the vips7 filename splitter ... this is very fragile and annoying
     # code with lots of cases
     def test_split7(self):
@@ -34,7 +34,7 @@ class TestIofuncs(PyvipsTester):
         ]
 
         for case in cases:
-            self.assertEqualObjects(split(case[0]), case[1])
+            assert_equal_objects(split(case[0]), case[1])
 
     def test_new_from_image(self):
         im = pyvips.Image.mask_ideal(100, 100, 0.5,
@@ -42,51 +42,52 @@ class TestIofuncs(PyvipsTester):
 
         im2 = im.new_from_image(12)
 
-        self.assertEqual(im2.width, im.width)
-        self.assertEqual(im2.height, im.height)
-        self.assertEqual(im2.interpretation, im.interpretation)
-        self.assertEqual(im2.format, im.format)
-        self.assertEqual(im2.xres, im.xres)
-        self.assertEqual(im2.yres, im.yres)
-        self.assertEqual(im2.xoffset, im.xoffset)
-        self.assertEqual(im2.yoffset, im.yoffset)
-        self.assertEqual(im2.bands, 1)
-        self.assertEqual(im2.avg(), 12)
+        assert im2.width == im.width
+        assert im2.height == im.height
+        assert im2.interpretation == im.interpretation
+        assert im2.format == im.format
+        assert im2.xres == im.xres
+        assert im2.yres == im.yres
+        assert im2.xoffset == im.xoffset
+        assert im2.yoffset == im.yoffset
+        assert im2.bands == 1
+        assert im2.avg() == 12
 
         im2 = im.new_from_image([1, 2, 3])
 
-        self.assertEqual(im2.bands, 3)
-        self.assertEqual(im2.avg(), 2)
+        assert im2.bands == 3
+        assert im2.avg() == 2
 
     def test_new_from_memory(self):
         s = bytearray(200)
         im = pyvips.Image.new_from_memory(s, 20, 10, 1, 'uchar')
 
-        self.assertEqual(im.width, 20)
-        self.assertEqual(im.height, 10)
-        self.assertEqual(im.format, 'uchar')
-        self.assertEqual(im.bands, 1)
-        self.assertEqual(im.avg(), 0)
+        assert im.width == 20
+        assert im.height == 10
+        assert im.format == 'uchar'
+        assert im.bands == 1
+        assert im.avg() == 0
 
         im += 10
 
-        self.assertEqual(im.avg(), 10)
+        assert im.avg() == 10
 
+    @pytest.mark.skipif(not pyvips.at_least_libvips(8, 5),
+                        reason="requires libvips >= 8.5")
     def test_get_fields(self):
-        if pyvips.at_least_libvips(8, 5):
-            im = pyvips.Image.black(10, 10)
-            fields = im.get_fields()
-            # we might add more fields later
-            self.assertTrue(len(fields) > 10)
-            self.assertEqual(fields[0], 'width')
+        im = pyvips.Image.black(10, 10)
+        fields = im.get_fields()
+        # we might add more fields later
+        assert len(fields) > 10
+        assert fields[0] == 'width'
 
     def test_write_to_memory(self):
         s = bytearray(200)
         im = pyvips.Image.new_from_memory(s, 20, 10, 1, 'uchar')
         t = im.write_to_memory()
 
-        self.assertEqual(s, t)
+        assert s == t
 
 
 if __name__ == '__main__':
-    unittest.main()
+    pytest.main()

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -1,24 +1,23 @@
 # vim: set fileencoding=utf-8 :
-import unittest
+import pytest
 
 import pyvips
-from .helpers import PyvipsTester
 
 
-class TestMorphology(PyvipsTester):
+class TestMorphology:
     def test_countlines(self):
         im = pyvips.Image.black(100, 100)
         im = im.draw_line(255, 0, 50, 100, 50)
         n_lines = im.countlines(pyvips.Direction.HORIZONTAL)
-        self.assertEqual(n_lines, 1)
+        assert n_lines == 1
 
     def test_labelregions(self):
         im = pyvips.Image.black(100, 100)
         im = im.draw_circle(255, 50, 50, 25, fill=True)
         mask, opts = im.labelregions(segments=True)
 
-        self.assertEqual(opts['segments'], 3)
-        self.assertEqual(mask.max(), 2)
+        assert opts['segments'] == 3
+        assert mask.max() == 2
 
     def test_erode(self):
         im = pyvips.Image.black(100, 100)
@@ -26,10 +25,10 @@ class TestMorphology(PyvipsTester):
         im2 = im.erode([[128, 255, 128],
                         [255, 255, 255],
                         [128, 255, 128]])
-        self.assertEqual(im.width, im2.width)
-        self.assertEqual(im.height, im2.height)
-        self.assertEqual(im.bands, im2.bands)
-        self.assertTrue(im.avg() > im2.avg())
+        assert im.width == im2.width
+        assert im.height == im2.height
+        assert im.bands == im2.bands
+        assert im.avg() > im2.avg()
 
     def test_dilate(self):
         im = pyvips.Image.black(100, 100)
@@ -37,20 +36,20 @@ class TestMorphology(PyvipsTester):
         im2 = im.dilate([[128, 255, 128],
                          [255, 255, 255],
                          [128, 255, 128]])
-        self.assertEqual(im.width, im2.width)
-        self.assertEqual(im.height, im2.height)
-        self.assertEqual(im.bands, im2.bands)
-        self.assertTrue(im2.avg() > im.avg())
+        assert im.width == im2.width
+        assert im.height == im2.height
+        assert im.bands == im2.bands
+        assert im2.avg() > im.avg()
 
     def test_rank(self):
         im = pyvips.Image.black(100, 100)
         im = im.draw_circle(255, 50, 50, 25, fill=True)
         im2 = im.rank(3, 3, 8)
-        self.assertEqual(im.width, im2.width)
-        self.assertEqual(im.height, im2.height)
-        self.assertEqual(im.bands, im2.bands)
-        self.assertTrue(im2.avg() > im.avg())
+        assert im.width == im2.width
+        assert im.height == im2.height
+        assert im.bands == im2.bands
+        assert im2.avg() > im.avg()
 
 
 if __name__ == '__main__':
-    unittest.main()
+    pytest.main()


### PR DESCRIPTION
Commits https://github.com/jcupitt/pyvips/commit/7e71ad9a7c784cc06fbad9b1b22f716261e30631, https://github.com/jcupitt/pyvips/commit/6cc99306765014f9fda55053424ff02161961f2a, https://github.com/jcupitt/pyvips/commit/87bf68a07c99a61dacdc5fea51e9c9dfa971652e and https://github.com/jcupitt/pyvips/commit/4180085e3bf6d0dd1f28233d4ac62198ebeb9814 were found when I worked on the unit tests of [net-vips](https://github.com/kleisauke/net-vips).

The last 2 commits (https://github.com/jcupitt/pyvips/commit/85975bf65a995e3943b96e9f09761f70cd838578 and https://github.com/jcupitt/pyvips/commit/f954246d2feef231cbd5025c3a7b30faacbf4557) were made because I had some spare time left today. :smile: